### PR TITLE
multi-fix

### DIFF
--- a/spp_idpass/__manifest__.py
+++ b/spp_idpass/__manifest__.py
@@ -17,6 +17,7 @@
         "views/registrant.xml",
         "security/ir.model.access.csv",
         "views/id_pass_view.xml",
+        "views/id_type.xml",
         "wizard/issue_id_pass_wizard.xml",
     ],
     "assets": {},

--- a/spp_idpass/data/id_pass.xml
+++ b/spp_idpass/data/id_pass.xml
@@ -1,9 +1,12 @@
-<odoo noupdate="1">
+<odoo noupdate="0">
     <!-- ID Type: ID Pass -->
-    <record id="id_template_idpass" model="spp.id.pass">
-        <field name="name">ID PASS Lite</field>
-    </record>
     <record id="id_type_idpass" model="g2p.id.type">
         <field name="name">ID PASS Lite</field>
+        <field name="target_type">both</field>
+    </record>
+
+    <record id="id_template_idpass" model="spp.id.pass">
+        <field name="name">ID PASS Template</field>
+        <field name="id_type" ref="id_type_idpass" />
     </record>
 </odoo>

--- a/spp_idpass/models/__init__.py
+++ b/spp_idpass/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import id_pass
 from . import registrant
+from . import id_type

--- a/spp_idpass/models/id_pass.py
+++ b/spp_idpass/models/id_pass.py
@@ -19,3 +19,4 @@ class OpenSPPIDPass(models.Model):
         default="years",
     )
     is_active = fields.Boolean("Active")
+    id_type = fields.Many2one("g2p.id.type")

--- a/spp_idpass/models/id_type.py
+++ b/spp_idpass/models/id_type.py
@@ -1,0 +1,33 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, fields, models
+from odoo.exceptions import ValidationError
+
+
+class OpenG2PIDType(models.Model):
+    _inherit = "g2p.id.type"
+
+    target_type = fields.Selection(
+        [("individual", "Individual"), ("group", "Group"), ("both", "Both")],
+        "Target Type",
+        default="individual",
+    )
+
+    def unlink(self):
+        for rec in self:
+            external_identifier = self.env["ir.model.data"].search(
+                [("res_id", "=", rec.id), ("model", "=", "g2p.id.type")]
+            )
+            if external_identifier.name == "id_type_idpass":
+                raise ValidationError(_("Can't delete default ID Type"))
+            else:
+                return super(OpenG2PIDType, self).unlink()
+
+    def write(self, vals):
+        external_identifier = self.env["ir.model.data"].search(
+            [("res_id", "=", self.id), ("model", "=", "g2p.id.type")]
+        )
+        if external_identifier.name == "id_type_idpass":
+            raise ValidationError(_("Can't edit default ID Type"))
+        else:
+            return super(OpenG2PIDType, self).write(vals)

--- a/spp_idpass/views/id_type.xml
+++ b/spp_idpass/views/id_type.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_id_type_tree_idpass" model="ir.ui.view">
+        <field name="name">view_id_type_tree_idpass</field>
+        <field name="model">g2p.id.type</field>
+        <field name="inherit_id" ref="g2p_registry_base.view_id_type_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+              <field name="target_type" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/spp_idqueue/models/id_queue.py
+++ b/spp_idqueue/models/id_queue.py
@@ -10,7 +10,7 @@ class OpenSPPIDQueue(models.Model):
     _description = "ID Queue"
 
     name = fields.Char("Request Name")
-    template_id = fields.Many2one("g2p.id.type", required=True)
+    id_type = fields.Many2one("g2p.id.type", required=True)
     idpass_id = fields.Many2one("spp.id.pass")
     requested_by = fields.Many2one("res.users", required=True)
     approved_by = fields.Many2one("res.users")
@@ -41,7 +41,7 @@ class OpenSPPIDQueue(models.Model):
 
     def print(self):
         for rec in self:
-            if rec.template_id.id == self.env.ref("spp_idpass.id_type_idpass").id:
+            if rec.id_type.id == self.env.ref("spp_idpass.id_type_idpass").id:
                 vals = {"idpass": self.idpass_id.id, "id_queue": self.id}
                 res_id = self.registrant_id.send_idpass_parameters(vals)
 

--- a/spp_idqueue/views/id_queue_view.xml
+++ b/spp_idqueue/views/id_queue_view.xml
@@ -7,7 +7,7 @@
             <tree create="false">
                 <field name="name" invisible="1" />
                 <field name="registrant_id" />
-                <field name="template_id" />
+                <field name="id_type" string="ID Type" />
                 <field name="requested_by" />
                 <field name="date_requested" />
                 <field name="date_printed" />

--- a/spp_idqueue/wizard/request_id_wizard.py
+++ b/spp_idqueue/wizard/request_id_wizard.py
@@ -13,13 +13,23 @@ class OpenSPPRequestIDWizard(models.TransientModel):
     _description = "Request ID Wizard"
 
     registrant_id = fields.Many2one("res.partner", "Registrant ID", required=True)
-    template_id = fields.Many2one("g2p.id.type")
+    id_type = fields.Many2one("g2p.id.type")
     is_idpass = fields.Boolean(default=False)
     idpass_id = fields.Many2one("spp.id.pass", "IDPass ID")
+    target_type = fields.Char(compute="_compute_target_type")
+
+    @api.depends("registrant_id")
+    def _compute_target_type(self):
+        for rec in self:
+            if rec.registrant_id:
+                if rec.registrant_id.is_group:
+                    rec.target_type = "group"
+                else:
+                    rec.target_type = "individual"
 
     def request_id(self):
         for rec in self:
-            if rec.template_id:
+            if rec.id_type:
                 params = self.env["ir.config_parameter"].sudo()
                 auto_approve_id_request = params.get_param(
                     "spp_id_queue.auto_approve_id_request"
@@ -28,7 +38,7 @@ class OpenSPPRequestIDWizard(models.TransientModel):
                 if auto_approve_id_request:
                     status = "approved"
                 vals = {
-                    "template_id": rec.template_id.id,
+                    "id_type": rec.id_type.id,
                     "idpass_id": rec.idpass_id.id or False,
                     "requested_by": self.env.user.id,
                     "date_requested": date.today(),
@@ -39,16 +49,16 @@ class OpenSPPRequestIDWizard(models.TransientModel):
             else:
                 raise UserError(_("There are no selected Template!"))
 
-    @api.onchange("template_id")
+    @api.onchange("id_type")
     def _onchange_template(self):
         for rec in self:
             rec.is_idpass = False
             _logger.info(
                 "ID REQUEST: %s %s"
-                % (rec.template_id.id, self.env.ref("spp_idpass.id_type_idpass").id)
+                % (rec.id_type.id, self.env.ref("spp_idpass.id_type_idpass").id)
             )
             if (
-                rec.template_id
-                and rec.template_id.id == self.env.ref("spp_idpass.id_type_idpass").id
+                rec.id_type
+                and rec.id_type.id == self.env.ref("spp_idpass.id_type_idpass").id
             ):
                 rec.is_idpass = True

--- a/spp_idqueue/wizard/request_id_wizard.xml
+++ b/spp_idqueue/wizard/request_id_wizard.xml
@@ -20,10 +20,13 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                         </div>
                     </div>
                     <group>
+                        <field name="target_type" invisible="1" />
                         <field
-                            name="template_id"
+                            name="id_type"
                             options="{'no_create_edit':True,'no_open':True,'no_create':True}"
                             attrs="{'required':[('registrant_id','=', True)]}"
+                            domain="[('target_type', '=', [target_type, 'both'])]"
+                            string="ID Type"
                         />
                         <field name="is_idpass" invisible="1" />
                         <field


### PR DESCRIPTION
- Moved the Unlink and Write Function (For IDPass)
- Added Target Type field (Selection: Individual, Group, Both) on ID Type to prevent requesting of ID if ID Type is for Group and the requesting Registrant is an Individual and vice versa. 
- Renamed ID Template to ID Type to prevent confusion.