### PR TITLE
[FIX] Fix phone field style direction in rlt language

### DIFF
--- a/spp_custom_fields_ui/__manifest__.py
+++ b/spp_custom_fields_ui/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["base", "g2p_registry_base"],
     "data": [
         "views/custom_fields_ui.xml",
+        "views/g2p_phone_number_views.xml",
     ],
     "assets": {
         "web.assets_backend": [

--- a/spp_custom_fields_ui/__manifest__.py
+++ b/spp_custom_fields_ui/__manifest__.py
@@ -13,7 +13,11 @@
     "data": [
         "views/custom_fields_ui.xml",
     ],
-    "assets": {},
+    "assets": {
+        "web.assets_backend": [
+            "spp_custom_fields_ui/static/src/js/basic_fields.js",
+        ],
+    },
     "demo": [],
     "images": [],
     "application": True,

--- a/spp_custom_fields_ui/static/src/js/basic_fields.js
+++ b/spp_custom_fields_ui/static/src/js/basic_fields.js
@@ -1,0 +1,24 @@
+/** @odoo-module **/
+
+import {FieldPhone} from "web.basic_fields";
+import {patch} from "web.utils";
+
+patch(FieldPhone.prototype, "spp_custom_fields_ui/static/src/js/basic_fields.js", {
+    /**
+     * @override
+     * @private
+     */
+    _onChange() {
+        this.$el.css("direction", "ltr");
+        this._super.apply(this, arguments);
+    },
+
+    /**
+     * @override
+     * @private
+     */
+    _onInput() {
+        this.$el.css("direction", "ltr");
+        this._super.apply(this, arguments);
+    },
+});

--- a/spp_custom_fields_ui/views/g2p_phone_number_views.xml
+++ b/spp_custom_fields_ui/views/g2p_phone_number_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_phone_number_tree_inherit_spp_custom_fields_ui" model="ir.ui.view">
+        <field name="name">g2p.phone.number.view.list.inherit</field>
+        <field name="model">g2p.phone.number</field>
+        <field name="inherit_id" ref="g2p_registry_base.view_phone_number_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='phone_no']" position="attributes">
+                <attribute name="widget">phone</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_phone_number_form_inherit_spp_custom_fields_ui" model="ir.ui.view">
+        <field name="name">g2p.phone.number.view.form.inherit</field>
+        <field name="model">g2p.phone.number</field>
+        <field name="inherit_id" ref="g2p_registry_base.view_phone_number_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='phone_no']" position="attributes">
+                <attribute name="widget">phone</attribute>
+            </xpath>
+            <xpath expr="//field[@name='phone_sanitized']" position="attributes">
+                <attribute name="widget">phone</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## What this PR does?

- The problem of FieldPhone that it is a child class of InputField.
- When the language choose to be right to left, all input fields css style was changed direction from `ltr` to `rtl`
- But, in displaying, FieldPhone is forced to be ltr in class `.o_field_phone`

-> so, technically, when editing this field, it is rtl, when displaying, it is ltr 

This PR will change the css styling of direction to ltr on edit & on change, for prevent this error happened.