### PR TITLE
[MISC] 186858 - Irrelevant category displayed on `Other Documents`

### DIFF
--- a/spp_change_request/views/dms_file_view.xml
+++ b/spp_change_request/views/dms_file_view.xml
@@ -28,6 +28,9 @@
                                 options="{'no_open': True,'no_create': True,'no_edit':True}"
                                 required="1"
                                 readonly="context.get('category_readonly')"
+                                domain="['|',
+                                ('parent_id', 'child_of', %(dms.category_01_demo)d),
+                                ('parent_id', 'child_of', %(dms.category_05_demo)d)]"
                             />
                         </h4>
                         <h2>


### PR DESCRIPTION
## What this PR does?

By domain filtering the category on `Other Documents` button to show extra documents categories.

![image](https://user-images.githubusercontent.com/31398072/213063795-09053eef-d755-4636-8bec-658a75d524fb.png)

Having a conversation with @gonzalesedwin1123 yesterday. He told me that other documents meant it is what left from existing documents, which is not Identity documents/ Requested forms or Certificates.