### PR TITLE
[MISC] remove the placeholder, only accept `Internal` document type

### DIFF
--- a/spp_change_request/views/dms_file_view.xml
+++ b/spp_change_request/views/dms_file_view.xml
@@ -24,13 +24,10 @@
                         <h4>
                             <field
                                 name="category_id"
-                                placeholder="Internal / Human Resource"
                                 options="{'no_open': True,'no_create': True,'no_edit':True}"
                                 required="1"
                                 readonly="context.get('category_readonly')"
-                                domain="['|',
-                                ('parent_id', 'child_of', %(dms.category_01_demo)d),
-                                ('parent_id', 'child_of', %(dms.category_05_demo)d)]"
+                                domain="[('parent_id', 'child_of', %(dms.category_01_demo)d)]"
                             />
                         </h4>
                         <h2>


### PR DESCRIPTION
## What this PR does?

So, after a conversation with Celine, she suggested me to remove the placeholder and only show the Internal document types

![image](https://user-images.githubusercontent.com/31398072/213344011-6fe8d72b-938d-4fc9-b845-c84b8622a31f.png)
<img src="https://user-images.githubusercontent.com/31398072/213344290-6f7fdf45-ceee-43fc-8835-ba4f8198093c.png">

