### PR TITLE
[FIX] for compatible with xmlrpc calling

### DIFF
--- a/spp_custom_filter/models/custom_filter_mixin.py
+++ b/spp_custom_filter/models/custom_filter_mixin.py
@@ -51,8 +51,10 @@ class CustomFilterMixin(models.AbstractModel):
                 allow_filter = getattr(self._fields[fname], "allow_filter", True)
             else:
                 allow_filter = getattr(self._fields[fname], "allow_filter", False)
-            res[fname]["searchable"] = allow_filter and res[fname].get("searchable")
-            res[fname]["exportable"] = allow_filter and res[fname].get("exportable")
+            if res[fname].get("searchable"):
+                res[fname]["searchable"] = allow_filter and res[fname]["searchable"]
+            if res[fname].get("exportable"):
+                res[fname]["exportable"] = allow_filter and res[fname]["exportable"]
 
         return res
 


### PR DESCRIPTION
## What this PR does?

On normal Odoo UI calling, Odoo js is always looking for "searchable", "exportable" on each field in Odoo model. But when in xmlrpc calling, devs may need less attributes from fields so this error is raised:

```python
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/controllers/rpc.py", line 93, in xmlrpc_2
    response = self._xmlrpc(service)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/controllers/rpc.py", line 74, in _xmlrpc
    return dumps((result,), methodresponse=1, allow_none=False)
  File "/usr/local/lib/python3.8/xmlrpc/client.py", line 968, in dumps
    data = m.dumps(params)
  File "/usr/local/lib/python3.8/xmlrpc/client.py", line 501, in dumps
    dump(v, write)
  File "/usr/local/lib/python3.8/xmlrpc/client.py", line 523, in __dump
    f(self, value, write)
  File "/usr/local/lib/python3.8/xmlrpc/client.py", line 594, in dump_struct
    dump(v, write)
  File "/usr/local/lib/python3.8/xmlrpc/client.py", line 523, in __dump
    f(self, value, write)
  File "/usr/local/lib/python3.8/xmlrpc/client.py", line 594, in dump_struct
    dump(v, write)
  File "/usr/local/lib/python3.8/xmlrpc/client.py", line 523, in __dump
    f(self, value, write)
  File "/usr/local/lib/python3.8/xmlrpc/client.py", line 527, in dump_nil
    raise TypeError("cannot marshal None unless allow_none is enabled")
TypeError: cannot marshal None unless allow_none is enabled
```
This PR fixes this error.