### PR TITLE
[ADD] proper error when too many records were selected for excel export

### DIFF
--- a/setup/spp_data_export/odoo/addons/spp_data_export
+++ b/setup/spp_data_export/odoo/addons/spp_data_export
@@ -1,0 +1,1 @@
+../../../../spp_data_export

--- a/setup/spp_data_export/setup.py
+++ b/setup/spp_data_export/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/spp_data_export/__init__.py
+++ b/spp_data_export/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/spp_data_export/__manifest__.py
+++ b/spp_data_export/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "PDS Data Export",
+    "category": "OpenSPP",
+    "version": "15.0.0.0.0",
+    "sequence": 1,
+    "author": "OpenSPP.org",
+    "website": "https://github.com/openspp/openspp-registry",
+    "license": "LGPL-3",
+    "development_status": "Alpha",
+    "maintainers": ["jeremi", "gonzalesedwin1123"],
+    "depends": [
+        "web",
+    ],
+    "application": False,
+    "installable": True,
+    "auto_install": False,
+}

--- a/spp_data_export/controllers/__init__.py
+++ b/spp_data_export/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/spp_data_export/controllers/main.py
+++ b/spp_data_export/controllers/main.py
@@ -1,0 +1,40 @@
+import json
+
+from odoo import _, http
+from odoo.exceptions import ValidationError
+from odoo.http import request
+
+from odoo.addons.web.controllers.main import ExcelExport, serialize_exception
+
+EXCEL_ROW_LIMIT = 1_048_576
+
+
+class SppExport(ExcelExport):
+    @http.route("/web/export/xlsx", type="http", auth="user")
+    @serialize_exception
+    def index(self, data):
+        """
+        In case too many records are selected to export, Odoo server will try to load all records then create
+        Excel report. At this time, due to timeout error, the Promise won't return and will raising an weird
+        error stack.
+
+        This function override the original function, to raise a properly error if the records count is more than
+        the limitation of Excel report, saving the time to generate report and fail.
+        """
+        json_data = json.loads(data)
+        if not json_data.get("ids"):
+            domain = json_data.get("domain")
+            model = json_data.get("model")
+            number_of_records = request.env[model].sudo().search_count(domain)
+            if number_of_records >= EXCEL_ROW_LIMIT:
+                raise ValidationError(
+                    _(
+                        "The number of record surpasses the limitation of Excel 2007-2013 (.xlsx) format "
+                        "[%(number_of_records)s records >= limit %(limit)s]. Please consider splitting the export."
+                    )
+                    % {
+                        "number_of_records": number_of_records,
+                        "limit": EXCEL_ROW_LIMIT,
+                    }
+                )
+        return super().index(data)


### PR DESCRIPTION
## What this PR does?

In case too many records are selected to export, Odoo server will try to load all records then create Excel report. At this time, due to timeout error, the Promise won't return and will raising a weird error stack. [this is something good since Odoo allow users to export record's relate data, like child records or m2m relationship, it should fails when load all data and find out that number of rows must create exceeds the limitation]

This PR is to create a faster response when the number of selected records surpass the limitation of Excel already.
