### PR TITLE
Set the custom field type to be editable and create functions to be used in compute field

### DIFF
--- a/spp_custom_fields_ui/models/__init__.py
+++ b/spp_custom_fields_ui/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
 
 from . import custom_fields_ui
+from . import reqistry

--- a/spp_custom_fields_ui/models/reqistry.py
+++ b/spp_custom_fields_ui/models/reqistry.py
@@ -8,7 +8,16 @@ class Registry(models.Model):
     _inherit = "res.partner"
 
     def _now(self):
+        """Get the current date
+        To be used in the custom field compute field code.
+        :return: Date - current date
+        """
         return fields.Date.today()
 
     def _relativedelta(self, **kwargs):
+        """
+        To be used in the custom field compute field code.
+        :param kwargs:
+        :return: dateutil.relativedelta
+        """
         return relativedelta(**kwargs)

--- a/spp_custom_fields_ui/models/reqistry.py
+++ b/spp_custom_fields_ui/models/reqistry.py
@@ -1,0 +1,14 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields, models
+
+
+class Registry(models.Model):
+    _inherit = "res.partner"
+
+    def _now(self):
+        return fields.Date.today()
+
+    def _relativedelta(self, **kwargs):
+        return relativedelta(**kwargs)

--- a/spp_custom_fields_ui/views/custom_fields_ui.xml
+++ b/spp_custom_fields_ui/views/custom_fields_ui.xml
@@ -34,7 +34,7 @@
                               <field name="model_id" readonly="1" force_save="1" />
                           </group>
                           <group>
-                              <field name="ttype" attrs="{'readonly': [('field_category','=','ind')]}" />
+                              <field name="ttype" />
                               <field name="target_type" />
                               <field name="field_category" />
                               <field


### PR DESCRIPTION
This PR provides the following:

- Set the field type to be editable
- Since call to fields and dateutil cannot be done in the custom field compute field code, the following functions are added in the res.partner model:
1. add function _now(self) - returns fields.Date.today()
2. add function _relativedelta(self, **kwargs) - returns dateutil.relativedelta(**kwargs)

The functions can be used in the custom fields UI like this:
![image](https://user-images.githubusercontent.com/87359145/226923895-170d96c9-0046-4e1d-99bf-1511ccb00ac0.png)
