### PR TITLE
[FIX] github action running: missing dependencies

### DIFF
--- a/spp_change_request/__manifest__.py
+++ b/spp_change_request/__manifest__.py
@@ -26,6 +26,7 @@
         "dms_field",
         "web_domain_field",
         "spp_idqueue",
+        "spp_event_data",
     ],
     "data": [
         "security/change_request_security.xml",

--- a/spp_change_request/tests/common.py
+++ b/spp_change_request/tests/common.py
@@ -2,8 +2,6 @@ from unittest.mock import patch
 
 from odoo.tests import TransactionCase
 
-from ..models.change_request import ChangeRequestBase
-
 
 class Common(TransactionCase):
     def setUp(self):
@@ -42,12 +40,17 @@ class Common(TransactionCase):
         vals.update({"is_registrant": True})
         return self.env["res.partner"].create(vals)
 
-    @patch.object(
-        ChangeRequestBase,
-        "_selection_request_type_ref_id",
-        return_value=[("test.request.type", "Test Request Type")],
+    @patch(
+        "odoo.addons.spp_change_request.models.change_request.ChangeRequestBase._selection_request_type_ref_id"
     )
-    def _create_change_request(self, name="Test Change Request"):
+    def _create_change_request(self, mock_request_type_selection):
+        mock_request_type_selection.return_value = [
+            ("test.request.type", "Test Request Type")
+        ]
+        mock_request_type_selection.__name__ = "_mocked__selection_request_type_ref_id"
         return self.env["spp.change.request"].create(
-            {"name": name, "request_type": "test.request.type"}
+            {
+                "name": "Test Request",
+                "request_type": "test.request.type",
+            }
         )


### PR DESCRIPTION
## What this PR does?
- Fixing mock patch test failures with new code from Odoo
- Fixing missing dependencies when install `spp_change_request` on GitHub action:
```python
2023-04-05 10:33:45,895 1792 CRITICAL odoo odoo.service.server: Failed to initialize database `odoo`. 
Traceback (most recent call last):
  File "/opt/odoo/odoo/service/server.py", line 1260, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/opt/odoo/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/opt/odoo/odoo/modules/loading.py", line 474, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/opt/odoo/odoo/modules/loading.py", line 363, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/opt/odoo/odoo/modules/loading.py", line 222, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/opt/odoo/odoo/modules/loading.py", line 69, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/opt/odoo/odoo/tools/convert.py", line 744, in convert_file
    convert_csv_import(cr, module, pathname, fp.read(), idref, mode, noupdate)
  File "/opt/odoo/odoo/tools/convert.py", line 790, in convert_csv_import
    raise Exception(_('Module loading %s failed: file %s could not be processed:\n %s') % (module, fname, warning_msg))
Exception: Module loading spp_change_request failed: file spp_change_request/security/ir.model.access.csv could not be processed:
 No matching record found for external id 'spp_event_data.model_spp_event_data' in field 'Model'
No matching record found for external id 'spp_event_data.model_spp_event_data' in field 'Model'
No matching record found for external id 'spp_event_data.model_spp_event_data' in field 'Model'
No matching record found for external id 'spp_event_data.model_spp_event_data' in field 'Model'
No matching record found for external id 'spp_event_data.model_spp_event_data' in field 'Model'
Missing required value for the field 'Model' (model_id)
Missing required value for the field 'Model' (model_id)
Missing required value for the field 'Model' (model_id)
Missing required value for the field 'Model' (model_id)
Missing required value for the field 'Model' (model_id)
```