### PR TITLE
[FIX] error with default params - mistake with ids and records

### DIFF
--- a/spp_change_request/models/change_request.py
+++ b/spp_change_request/models/change_request.py
@@ -668,7 +668,7 @@ class ChangeRequestBase(models.Model):
         for rec in self:
             # Open Request Form
             mode = "edit"
-            if self.env.user.id not in [self.assign_to_id.id, self.create_uid]:
+            if self.env.user.id not in [self.assign_to_id.id, self.create_uid.id]:
                 mode = "readonly"
             return rec.open_change_request_form(target="current", mode=mode)
 

--- a/spp_idqueue/wizard/batch_create_wizard.py
+++ b/spp_idqueue/wizard/batch_create_wizard.py
@@ -33,10 +33,10 @@ class OpenSPPBatchCreateWizard(models.TransientModel):
             if len(queue_id) > 0:
                 templates = queue_id.mapped("idpass_id.id")
                 if len(set(templates)) > 1:
-                    res["queue_ids"] = queue_id
+                    res["queue_ids"] = [(6, 0, queue_id.ids)]
                     res["state"] = "step1"
                 else:
-                    res["queue_ids"] = queue_id
+                    res["queue_ids"] = [(6, 0, queue_id.ids)]
                     res["id_count"] = len(queue_id)
                     res["state"] = "step2"
             else:

--- a/spp_idqueue/wizard/multi_id_request_wizard.py
+++ b/spp_idqueue/wizard/multi_id_request_wizard.py
@@ -21,11 +21,7 @@ class OpenSPPMultiIDRequestWizard(models.TransientModel):
         """
         res = super(OpenSPPMultiIDRequestWizard, self).default_get(fields)
         if self.env.context.get("active_ids"):
-            registrant_ids = self.env["res.partner"].search(
-                [("id", "in", self.env.context.get("active_ids"))]
-            )
-            if registrant_ids:
-                res["registrant_ids"] = registrant_ids
+            res["registrant_ids"] = [(6, 0, self._context.get("active_ids"))]
             return res
         else:
             raise UserError(_("There are no selected Registrants!"))


### PR DESCRIPTION
## What this PR does?

- Default params with relationship fields (m2o, x2m) should get ids instead of records. This PR fix warning raised to Sentry