### PR TITLE
[ADD] spp_custom_field_recompute_daily: recompute daily indicator fields by params and cron job

### DIFF
--- a/setup/spp_custom_field_recompute_daily/odoo/addons/spp_custom_field_recompute_daily
+++ b/setup/spp_custom_field_recompute_daily/odoo/addons/spp_custom_field_recompute_daily
@@ -1,0 +1,1 @@
+../../../../spp_custom_field_recompute_daily

--- a/setup/spp_custom_field_recompute_daily/setup.py
+++ b/setup/spp_custom_field_recompute_daily/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/spp_custom_field_recompute_daily/__init__.py
+++ b/spp_custom_field_recompute_daily/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/spp_custom_field_recompute_daily/__manifest__.py
+++ b/spp_custom_field_recompute_daily/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["base_setup", "queue_job"],
     "data": [
         "data/ir_cron_data.xml",
+        "security/ir.model.access.csv",
         "views/ir_model_fields_views.xml",
         "views/res_config_settings_views.xml",
     ],

--- a/spp_custom_field_recompute_daily/__manifest__.py
+++ b/spp_custom_field_recompute_daily/__manifest__.py
@@ -1,0 +1,21 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+{
+    "name": "OpenSPP Custom Field: Recompute Daily",
+    "category": "OpenSPP",
+    "version": "15.0.0.0.0",
+    "sequence": 1,
+    "author": "OpenSPP.org",
+    "website": "https://github.com/openspp/openspp-registry",
+    "license": "LGPL-3",
+    "development_status": "Alpha",
+    "maintainers": ["jeremi", "gonzalesedwin1123", "nhatnm0612"],
+    "depends": ["base_setup", "queue_job"],
+    "data": [
+        "data/ir_cron_data.xml",
+        "views/ir_model_fields_views.xml",
+        "views/res_config_settings_views.xml",
+    ],
+    "application": True,
+    "installable": True,
+    "auto_install": False,
+}

--- a/spp_custom_field_recompute_daily/data/ir_cron_data.xml
+++ b/spp_custom_field_recompute_daily/data/ir_cron_data.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+
+    <function model="ir.model.fields" name="create_daily_recompute_cron" />
+
+</odoo>

--- a/spp_custom_field_recompute_daily/models/__init__.py
+++ b/spp_custom_field_recompute_daily/models/__init__.py
@@ -1,3 +1,4 @@
 from . import base
 from . import ir_model_fields
 from . import res_config_settings
+from . import test_daily_recompute_model

--- a/spp_custom_field_recompute_daily/models/__init__.py
+++ b/spp_custom_field_recompute_daily/models/__init__.py
@@ -1,0 +1,3 @@
+from . import base
+from . import ir_model_fields
+from . import res_config_settings

--- a/spp_custom_field_recompute_daily/models/base.py
+++ b/spp_custom_field_recompute_daily/models/base.py
@@ -1,0 +1,8 @@
+from odoo import models
+
+
+class Base(models.AbstractModel):
+    _inherit = "base"
+
+    def _valid_field_parameter(self, field, name):
+        return name == "recompute_daily" or super()._valid_field_parameter(field, name)

--- a/spp_custom_field_recompute_daily/models/ir_model_fields.py
+++ b/spp_custom_field_recompute_daily/models/ir_model_fields.py
@@ -1,0 +1,91 @@
+import logging
+
+from pytz import timezone
+
+from odoo import SUPERUSER_ID, api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class IrModelFields(models.Model):
+    _inherit = "ir.model.fields"
+
+    recompute_daily = fields.Boolean(
+        string="Daily Recompute",
+        default=False,
+        help="Whether or not this field should be recompute daily by cron jobs!",
+    )
+
+    def _reflect_field_params(self, field, model_id):
+        vals = super(IrModelFields, self)._reflect_field_params(field, model_id)
+        compute = getattr(field, "compute", False) or getattr(field, "related", False)
+        store = getattr(field, "store", False)
+        recompute_daily = getattr(field, "recompute_daily", False)
+        if recompute_daily and not all([compute, store]):
+            _logger.warning(
+                "Non-compute-stored field: (%s, %s) on model '%s' "
+                "is not allowed to be recomputed daily!"
+                % (field.name, field.string, field.model_name)
+            )
+            recompute_daily = False
+        vals["recompute_daily"] = recompute_daily
+        return vals
+
+    def _instanciate_attrs(self, field_data):
+        attrs = super(IrModelFields, self)._instanciate_attrs(field_data)
+        if attrs and field_data.get("recompute_daily"):
+            attrs["recompute_daily"] = field_data["recompute_daily"]
+        return attrs
+
+    @api.model
+    def _daily_recompute_indicators(self):
+        maximum_daily_recompute_count = int(
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("spp.maximum_daily_recompute_count", "10_000")
+        )
+        recompute_daily_fields = self.search([("recompute_daily", "=", True)])
+        for field in recompute_daily_fields:
+            model = self.env[field.model_id.model]
+            total_records_count = model.search_count([])
+            records = model.search([])
+            if total_records_count <= maximum_daily_recompute_count:
+                field._recompute_indicator_on_records(records)
+                continue
+            for i in range(0, total_records_count, maximum_daily_recompute_count):
+                field.with_delay()._recompute_indicator_on_records(
+                    records[i : (i + maximum_daily_recompute_count)]
+                )
+
+    def _recompute_indicator_on_records(self, records_to_compute):
+        self.ensure_one()
+        return self.env.add_to_compute(
+            records_to_compute._fields[self.name], records_to_compute
+        )
+
+    @api.model
+    def create_daily_recompute_cron(self):
+        ADMINUSER_ID = 2
+        self = self.with_user(ADMINUSER_ID)
+        tz = self._context.get("tz") or self.env.user.tz or "UTC"
+        local = timezone(tz)
+        local_1am = local.localize(
+            fields.Datetime.add(fields.Datetime.now(), days=1).replace(
+                hour=1, minute=0, second=0
+            )
+        )
+        utc_for_local_1am = local_1am.astimezone(timezone("utc"))
+        self.env["ir.cron"].sudo().create(
+            {
+                "name": "## Indicator: Daily Recompute Fields",
+                "interval_number": 1,
+                "interval_type": "days",
+                "numbercall": -1,
+                "doall": False,
+                "model_id": self.env.ref("base.model_ir_model_fields").id,
+                "state": "code",
+                "code": "model._daily_recompute_indicators()",
+                "nextcall": utc_for_local_1am.strftime("%Y-%m-%d %H:%M:%S"),
+                "user_id": SUPERUSER_ID,
+            }
+        )

--- a/spp_custom_field_recompute_daily/models/res_config_settings.py
+++ b/spp_custom_field_recompute_daily/models/res_config_settings.py
@@ -1,0 +1,12 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    maximum_daily_recompute_count = fields.Integer(
+        string="Maximum Daily Recompute Records Count",
+        default=10_000,
+        config_parameter="spp.maximum_daily_recompute_count",
+        help="Maximum number of records for synchronous recomputing fields.",
+    )

--- a/spp_custom_field_recompute_daily/models/test_daily_recompute_model.py
+++ b/spp_custom_field_recompute_daily/models/test_daily_recompute_model.py
@@ -1,0 +1,33 @@
+from odoo import fields, models
+
+
+class TestDailyRecomputeModel(models.TransientModel):
+    _name = "spp.test.daily.recompute.model"
+    _description = "Test Daily Recompute Model"
+
+    field_to_test_1 = fields.Char(
+        string="Field to Test 1",
+        compute="_compute_field_to_test_1",
+        store=True,
+        recompute_daily=True,
+    )
+    # test recompute daily with compute non-stored field
+    field_to_test_2 = fields.Char(
+        string="Field to Test 2",
+        compute="_compute_field_to_test_2",
+        store=False,
+        recompute_daily=True,
+    )
+    # test recompute daily with non-computed field
+    field_to_test_3 = fields.Char(
+        string="Field to Test 3",
+        recompute_daily=True,
+    )
+
+    def _compute_field_to_test_1(self):
+        for rec in self:
+            rec.field_to_test_1 = "1"
+
+    def _compute_field_to_test_2(self):
+        for rec in self:
+            rec.field_to_test_2 = "2"

--- a/spp_custom_field_recompute_daily/security/ir.model.access.csv
+++ b/spp_custom_field_recompute_daily/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+spp_custom_field_recompute_daily.access_spp_test_daily_recompute_model,access_spp_test_daily_recompute_model,spp_custom_field_recompute_daily.model_spp_test_daily_recompute_model,base.group_user,1,0,0,0

--- a/spp_custom_field_recompute_daily/tests/__init__.py
+++ b/spp_custom_field_recompute_daily/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_ir_model_fields

--- a/spp_custom_field_recompute_daily/tests/test_ir_model_fields.py
+++ b/spp_custom_field_recompute_daily/tests/test_ir_model_fields.py
@@ -1,0 +1,102 @@
+from odoo.tests import TransactionCase
+
+
+class TestIrModelFields(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.test_model = self.env["spp.test.daily.recompute.model"]
+        self.test_field_1 = self.test_model._fields["field_to_test_1"]
+        self.test_field_2 = self.test_model._fields["field_to_test_2"]
+        self.test_field_3 = self.test_model._fields["field_to_test_3"]
+        self.model_id = self.env.ref(
+            "spp_custom_field_recompute_daily.model_spp_test_daily_recompute_model"
+        ).id
+
+    def _create_test_record(self):
+        return self.test_model.create(
+            {
+                "field_to_test_1": "101",
+                "field_to_test_2": "202",
+                "field_to_test_3": "303",
+            }
+        )
+
+    def test_01_reflect_field_params(self):
+        field_1_data = self.env["ir.model.fields"]._reflect_field_params(
+            self.test_field_1,
+            self.model_id,
+        )
+        self.assertTrue(
+            field_1_data["recompute_daily"],
+            "Field 1 should be recomputed daily as defined",
+        )
+        with self.assertLogs(
+            "odoo.addons.spp_custom_field_recompute_daily.models.ir_model_fields",
+            level="WARNING",
+        ) as log_catcher:
+            field_2_data = self.env["ir.model.fields"]._reflect_field_params(
+                self.test_field_2,
+                self.model_id,
+            )
+            self.assertFalse(
+                field_2_data["recompute_daily"],
+                "Field 2 should not be recomputed daily as defined [non-stored field]",
+            )
+            field_3_data = self.env["ir.model.fields"]._reflect_field_params(
+                self.test_field_3,
+                self.model_id,
+            )
+            self.assertFalse(
+                field_3_data["recompute_daily"],
+                "Field 3 should not be recomputed daily as defined [non-computed field]",
+            )
+            for warning in log_catcher.output:
+                self.assertRegex(
+                    warning,
+                    r"Non-compute-stored field.*is not allowed to be recomputed daily!",
+                    "Warning should be raised for Field 2 and Field 3!",
+                )
+
+    def test_02_recompute_indicator_on_records(self):
+        test_record = self._create_test_record()
+        test_field = self.env["ir.model.fields"].search(
+            [("recompute_daily", "=", True)]
+        )
+        test_field._recompute_indicator_on_records(test_record)
+        fields_to_compute = self.env.fields_to_compute()
+        self.assertIn(
+            self.test_field_1,
+            fields_to_compute,
+            "Field 1 should be marked as fields to compute in environment!",
+        )
+
+    def test_03_daily_recompute_indicators(self):
+        self._create_test_record()
+        self._create_test_record()
+        self.env["ir.model.fields"]._daily_recompute_indicators()
+        fields_to_compute = self.env.fields_to_compute()
+        self.assertIn(
+            self.test_field_1,
+            fields_to_compute,
+            "Field 1 should be marked as fields to compute in environment!",
+        )
+        recompute_indicator_jobs_count = self.env["queue.job"].search_count(
+            [("func_string", "like", "_recompute_indicator_on_records")]
+        )
+        self.assertFalse(
+            bool(recompute_indicator_jobs_count),
+            "Jobs should not exists before reset max daily recompute "
+            "record count and recompute indicators!",
+        )
+        self.env["ir.config_parameter"].set_param(
+            "spp.maximum_daily_recompute_count", "1"
+        )
+        self.env["ir.model.fields"]._daily_recompute_indicators()
+        recompute_indicator_jobs_count = self.env["queue.job"].search_count(
+            [("func_string", "like", "_recompute_indicator_on_records")]
+        )
+        self.assertTrue(
+            bool(recompute_indicator_jobs_count),
+            "Jobs should exists after reset max daily recompute "
+            "record count and recompute indicators!",
+        )

--- a/spp_custom_field_recompute_daily/views/ir_model_fields_views.xml
+++ b/spp_custom_field_recompute_daily/views/ir_model_fields_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_model_fields_form_inherit_spp_custom_field_recompute_daily" model="ir.ui.view">
+        <field name="name">ir.model.fields.view.form.inherit</field>
+        <field name="model">ir.model.fields</field>
+        <field name="inherit_id" ref="base.view_model_fields_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[@name='base']//field[@name='copied']" position="after">
+                <field name="recompute_daily" groups="base.group_no_one" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_model_fields_tree_inherit_spp_custom_field_recompute_daily" model="ir.ui.view">
+        <field name="name">ir.model.fields.view.list.inherit</field>
+        <field name="model">ir.model.fields</field>
+        <field name="inherit_id" ref="base.view_model_fields_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='readonly']" position="after">
+                <field name="recompute_daily" groups="base.group_no_one" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_model_fields_search_inherit_spp_custom_field_recompute_daily" model="ir.ui.view">
+        <field name="name">ir.model.fields.view.search.inherit</field>
+        <field name="model">ir.model.fields</field>
+        <field name="inherit_id" ref="base.view_model_fields_search" />
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='translate']" position="after">
+                <separator />
+                <filter
+                    name="daily_recompute"
+                    string="Daily Recompute"
+                    domain="[('recompute_daily', '=', True)]"
+                />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/spp_custom_field_recompute_daily/views/res_config_settings_views.xml
+++ b/spp_custom_field_recompute_daily/views/res_config_settings_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="res_config_settings_view_form_inherit_spp_custom_field_recompute_daily" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='companies']" position="after">
+                <div id="recompute_daily">
+                    <h2>Daily Recomputing</h2>
+                    <div class="row mt16 o_settings_container" name="recompute_daily_setting_container">
+                        <div class="col-xs-12 col-md-6 o_setting_box" id="recompute_daily_setting">
+                            <div class="o_setting_right_pane">
+                                <label for="maximum_daily_recompute_count" />
+                                <div class="text-muted">
+                                    Set maximum number of records for synchronous recomputing fields.
+                                </div>
+                                <field name="maximum_daily_recompute_count" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## What this PR does?

- [x] Add fields param `recompute_daily` [bool] for marking this field to be recompute daily by cron.
- [x] Create cron to execute recompute field by 1 AM local time.
- [x] Testcases for new module

Close: #216 