### PR TITLE
Migrate 17.1.1 change request

### DIFF
--- a/spp_change_request/__manifest__.py
+++ b/spp_change_request/__manifest__.py
@@ -45,8 +45,9 @@
     "assets": {
         "web.assets_backend": [
             "spp_change_request/static/src/scss/change_request.scss",
-            "spp_change_request/static/src/js/hide_button.js",
-            "spp_change_request/static/src/js/dms_preview.js",
+            # deprecated javascript function/class, need to find a way to fix those
+            # "spp_change_request/static/src/js/hide_button.js",
+            # "spp_change_request/static/src/js/dms_preview.js",
         ],
         "web.assets_qweb": {
             "/spp_change_request/static/src/xml/dms_preview_widget.xml",

--- a/spp_change_request/tests/common.py
+++ b/spp_change_request/tests/common.py
@@ -4,11 +4,12 @@ from odoo.tests import TransactionCase
 
 
 class Common(TransactionCase):
-    def setUp(self):
-        self._test_individual_1 = self._create_registrant({"name": "Liu Bei"})
-        self._test_individual_2 = self._create_registrant({"name": "Guan Yu"})
-        self._test_individual_3 = self._create_registrant({"name": "Zhang Fei"})
-        self._test_group = self._create_registrant(
+    @classmethod
+    def setUpClass(cls):
+        cls._test_individual_1 = cls._create_registrant({"name": "Liu Bei"})
+        cls._test_individual_2 = cls._create_registrant({"name": "Guan Yu"})
+        cls._test_individual_3 = cls._create_registrant({"name": "Zhang Fei"})
+        cls._test_group = cls._create_registrant(
             {
                 "name": "Shu clan",
                 "is_group": True,
@@ -17,23 +18,23 @@ class Common(TransactionCase):
                         0,
                         0,
                         {
-                            "individual": self._test_individual_1.id,
+                            "individual": cls._test_individual_1.id,
                             "kind": [
                                 (
                                     4,
-                                    self.env.ref(
+                                    cls.env.ref(
                                         "g2p_registry_membership.group_membership_kind_head"
                                     ).id,
                                 )
                             ],
                         },
                     ),
-                    (0, 0, {"individual": self._test_individual_2.id}),
-                    (0, 0, {"individual": self._test_individual_3.id}),
+                    (0, 0, {"individual": cls._test_individual_2.id}),
+                    (0, 0, {"individual": cls._test_individual_3.id}),
                 ],
             }
         )
-        return super().setUp()
+        return super().setUpClass()
 
     def _create_registrant(self, vals):
         assert type(vals) == dict

--- a/spp_change_request/tests/test_change_requests.py
+++ b/spp_change_request/tests/test_change_requests.py
@@ -8,9 +8,10 @@ from .common import Common
 
 
 class TestChangeRequests(Common):
-    def setUp(self):
-        super().setUp()
-        self._test_change_request = self._create_change_request()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._test_change_request = cls._create_change_request()
 
     def test_01_create(self):
         self.assertEqual(

--- a/spp_change_request/views/change_request_view.xml
+++ b/spp_change_request/views/change_request_view.xml
@@ -14,7 +14,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                     help="Open Details"
                     icon="fa-external-link "
                     class="btn-success"
-                    attrs="{'invisible':[('request_type_ref_id','=',False)]}"
+                    invisible="not request_type_ref_id"
                     context="{'show_validation_form':True}"
                     groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_applicator"
                 />
@@ -24,14 +24,14 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                 <field name="request_type" />
                 <field name="registrant_id" />
                 <field name="applicant_id" />
-                <field name="request_type_ref_id" invisible="1" />
+                <field name="request_type_ref_id" column_invisible="1" />
                 <field name="assign_to_id" widget="many2one_avatar_user" />
                 <field name="last_validated_by_id" widget="many2one_avatar_user" />
                 <field name="date_validated" />
                 <field name="applied_by_id" widget="many2one_avatar_user" />
                 <field name="date_applied" />
                 <field name="activity_ids" widget="list_activity" optional="show" />
-                <field name="date_rejected" invisible="1" />
+                <field name="date_rejected" column_invisible="1" />
                 <field name="company_id" groups="base.group_multi_company" />
                 <field
                     name="state"
@@ -59,7 +59,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                         string="Request Validation"
                         icon="fa-paper-plane"
                         class="btn-primary"
-                        states="draft"
+                        invisible="state != 'draft'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_agent"
                     />
                     <button
@@ -68,7 +68,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                         string="Validate"
                         icon="fa-check-square-o"
                         class="btn-warning"
-                        states="pending"
+                        invisible="state != 'pending'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator"
                     />
                     <button
@@ -77,7 +77,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                         string="Apply Changes"
                         icon="fa-thumbs-o-up"
                         class="btn-success"
-                        states="validated"
+                        invisible="state != 'validated'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_applicator"
                     />
                     <button
@@ -86,7 +86,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                         string="Reject"
                         icon="fa-ban"
                         class="btn-danger"
-                        states="pending"
+                        invisible="state != 'pending'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_validator"
                     />
                     <button
@@ -95,7 +95,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                         string="Cancel Change Request"
                         icon="fa-times-circle"
                         class="btn-default"
-                        states="draft,pending,rejected,validated"
+                        invisible="state not in  ['draft', 'pending', 'rejected', 'validated']"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_agent"
                     />
                     <button
@@ -104,7 +104,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                         string="Reset to Draft"
                         icon="fa-rotate-left"
                         class="btn-success"
-                        states="rejected"
+                        invisible="state != 'rejected'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_agent"
                     />
                     <field
@@ -116,7 +116,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                 <div
                     class="alert alert-danger text-center o_form_header"
                     role="status"
-                    attrs="{'invisible': [('rejected_by_id', '=', False)]}"
+                    invisible="not rejected_by_id"
                 >
                     This change request was REJECTED.
                 </div>
@@ -130,50 +130,39 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                             class="oe_stat_button"
                             groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_validator,spp_change_request.group_spp_change_request_applicator,spp_change_request.group_spp_change_request_agent,spp_change_request.group_spp_change_request_administrator"
                         >
-                            <div
-                                class="o_form_field o_stat_info"
-                                attrs="{'invisible': [('current_user_assigned', '!=', False)]}"
-                            >
+                            <div class="o_form_field o_stat_info" invisible="current_user_assigned">
                                 <span class="o_stat_text">Assign</span>
                                 <span class="o_stat_text">To Me</span>
                             </div>
-                            <div
-                                class="o_form_field o_stat_info"
-                                attrs="{'invisible': [('current_user_assigned', '!=', True)]}"
-                            >
+                            <div class="o_form_field o_stat_info" invisible="not current_user_assigned">
                                 <span class="o_stat_text">Reassign</span>
                             </div>
                         </button>
                     </div>
-                    <widget
-                        name="web_ribbon"
-                        title="Draft"
-                        bg_color="bg-info"
-                        attrs="{'invisible': [('state', '!=', 'draft')]}"
-                    />
+                    <widget name="web_ribbon" title="Draft" bg_color="bg-info" invisible="state != 'draft'" />
                     <widget
                         name="web_ribbon"
                         title="Pending Validation"
                         bg_color="bg-primary"
-                        attrs="{'invisible': [('state', '!=', 'pending')]}"
+                        invisible="state != 'pending'"
                     />
                     <widget
                         name="web_ribbon"
                         title="Validated"
                         bg_color="bg-warning"
-                        attrs="{'invisible': [('state', '!=', 'validated')]}"
+                        invisible="state != 'validated'"
                     />
                     <widget
                         name="web_ribbon"
                         title="Applied"
                         bg_color="bg-success"
-                        attrs="{'invisible': [('state', '!=', 'applied')]}"
+                        invisible="state != 'applied'"
                     />
                     <widget
                         name="web_ribbon"
                         title="Rejected"
                         bg_color="bg-danger"
-                        attrs="{'invisible': [('state', '!=', 'rejected')]}"
+                        invisible="state != 'rejected'"
                     />
                     <div class="oe_title mb24">
                         <label for="name" string="Request #:" />
@@ -182,17 +171,14 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                         </h1>
                         <label for="request_type" string="Request Type:" />
                         <h2>
-                            <field
-                                name="request_type"
-                                attrs="{'readonly':['|', ('state','!=','draft'), ('request_type_ref_id','!=',False)]}"
-                            />
+                            <field name="request_type" readonly="state != 'draft' or request_type_ref_id" />
                         </h2>
                         <label for="registrant_id" string="Registrant:" />
                         <h2>
                             <field
                                 name="registrant_id"
                                 options="{'no_create': True,'no_open':True}"
-                                attrs="{'readonly':['|',('state','!=','draft'),('request_type_ref_id','!=',False)]}"
+                                readonly="state != 'draft' or request_type_ref_id"
                                 class="oe_inline"
                             />
                             <field
@@ -201,7 +187,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                                 icon="fa-qrcode"
                                 string="Scan QR Code"
                                 colspan="4"
-                                attrs="{'invisible':['|',('state','!=','draft'),('request_type_ref_id','!=',False)]}"
+                                invisible="state != 'draft' or request_type_ref_id"
                                 class="oe_inline"
                                 style="margin-left: 10px;"
                             />
@@ -211,7 +197,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                             <field
                                 name="applicant_id"
                                 options="{'no_create': True,'no_open':True}"
-                                attrs="{'readonly':['|',('state','!=','draft'),('request_type_ref_id','!=',False)]}"
+                                readonly="state != 'draft' or request_type_ref_id"
                                 domain="applicant_id_domain"
                                 required="1"
                                 force_save="1"
@@ -224,7 +210,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                                 icon="fa-id-card-o"
                                 string="Scan ID Document"
                                 colspan="4"
-                                attrs="{'invisible':['|',('state','!=','draft'),('request_type_ref_id','!=',False)]}"
+                                invisible="state != 'draft' or request_type_ref_id"
                                 style="margin-left: 10px;"
                                 class="oe_inline"
                             />
@@ -233,7 +219,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                                 type="object"
                                 icon="fa-external-link"
                                 class="btn-success oe_inline"
-                                attrs="{'invisible':[('applicant_id','=',False)]}"
+                                invisible="not applicant_id"
                                 style="margin-left: 10px;"
                             />
                         </h3>
@@ -244,38 +230,36 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                             string="Phone No."
                             widget="phone"
                             options="{'enable_sms': false}"
-                            attrs="{'readonly':[('state','!=','draft')]}"
+                            readonly="state != 'draft'"
                         />
                     </group>
-                    <footer class="o_footer_bg">
-                        <button
-                            name="create_request_detail"
-                            type="object"
-                            string="NEXT"
-                            icon="fa-chevron-circle-right"
-                            class="btn-primary"
-                            attrs="{'invisible':['|', ('request_type_ref_id','!=',False), ('id', '=', False)]}"
-                            style="margin-left: 10px;"
-                        />
-                        <button
-                            name="create_request_detail_no_redirect"
-                            type="object"
-                            string="CREATE"
-                            icon="fa-chevron-circle-right"
-                            class="btn-primary"
-                            attrs="{'invisible':['|', ('request_type_ref_id','!=',False), ('id', '!=', False)]}"
-                            style="margin-left: 10px;"
-                        />
-                        <button
-                            name="open_request_detail"
-                            type="object"
-                            string="NEXT"
-                            icon="fa-chevron-circle-right"
-                            class="btn-warning"
-                            attrs="{'invisible':[('request_type_ref_id','=',False)]}"
-                            style="margin-left: 10px;"
-                        />
-                    </footer>
+                    <button
+                        name="create_request_detail"
+                        type="object"
+                        string="NEXT"
+                        icon="fa-chevron-circle-right"
+                        class="btn-primary"
+                        invisible="request_type_ref_id or not id"
+                        style="margin-left: 10px;"
+                    />
+                    <button
+                        name="create_request_detail_no_redirect"
+                        type="object"
+                        string="CREATE"
+                        icon="fa-chevron-circle-right"
+                        class="btn-primary"
+                        invisible="request_type_ref_id or id"
+                        style="margin-left: 10px;"
+                    />
+                    <button
+                        name="open_request_detail"
+                        type="object"
+                        string="NEXT"
+                        icon="fa-chevron-circle-right"
+                        class="btn-warning"
+                        invisible="not request_type_ref_id"
+                        style="margin-left: 10px;"
+                    />
                     <group colspan="4" col="4" string="Monitoring">
                         <field
                             name="assign_to_id"
@@ -288,7 +272,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                             groups="base.group_multi_company"
                             options="{'no_create': True}"
                             force_save="1"
-                            attrs="{'readonly':[('state','!=','draft')]}"
+                            readonly="state != 'draft'"
                         />
                         <field name="date_requested" readonly="1" />
                         <field

--- a/spp_change_request/views/dms_file_view.xml
+++ b/spp_change_request/views/dms_file_view.xml
@@ -6,12 +6,7 @@
         <field name="arch" type="xml">
             <form string="Files">
                 <sheet>
-                    <widget
-                        name="web_ribbon"
-                        title="Archived"
-                        bg_color="bg-danger"
-                        attrs="{'invisible': [('active', '=', True)]}"
-                    />
+                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" invisible="active" />
                     <div class="oe_button_box" name="button_box" />
                     <field
                         name="image_1920"
@@ -55,7 +50,7 @@
                                 name="path_json"
                                 widget="path_json"
                                 options="{'prefix': True, 'suffix': False}"
-                                attrs="{'invisible': ['|', ('name', '=', False), ('directory_id', '=', False)]}"
+                                invisible="not name or not directory_id"
                                 string="Path"
                             />
                         </group>

--- a/spp_change_request/views/registrant_view.xml
+++ b/spp_change_request/views/registrant_view.xml
@@ -8,24 +8,23 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
         <field name="name">view_group_ext_form_custom_spp_cr</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="g2p_registry_group.view_groups_form" />
-        <field
-            name="groups_id"
-            eval="[(4, ref('g2p_registry_base.group_g2p_registrar')), (4, ref('g2p_registry_base.group_g2p_admin'))]"
-        />
         <field name="arch" type="xml">
             <xpath expr="//page[@name='other']" position="before">
-                <page string="Change Requests">
+                <page
+                    string="Change Requests"
+                    groups="g2p_registry_base.group_g2p_registrar,g2p_registry_base.group_g2p_admin"
+                >
                     <field name="change_request_ids" readonly="1" nolabel="1">
                         <tree editable="top">
                             <field name="name" />
                             <field name="date_requested" />
                             <field name="create_uid" string="Requested By" widget="many2one_avatar_user" />
                             <field name="request_type" />
-                            <field name="registrant_id" invisible="1" />
+                            <field name="registrant_id" column_invisible="1" />
                             <field name="applicant_id" />
-                            <field name="request_type_ref_id" invisible="1" />
+                            <field name="request_type_ref_id" column_invisible="1" />
                             <field name="assign_to_id" widget="many2one_avatar_user" />
-                            <field name="date_rejected" invisible="1" />
+                            <field name="date_rejected" column_invisible="1" />
                             <field name="company_id" groups="base.group_multi_company" />
                             <field
                                 name="state"

--- a/spp_change_request/wizard/confirm_user_assignment_view.xml
+++ b/spp_change_request/wizard/confirm_user_assignment_view.xml
@@ -18,7 +18,7 @@
                         <field
                             name="assign_to_id"
                             options="{'no_create':True,'no_edit':True,'no_open':True}"
-                            attrs="{'invisible':[('assign_to_any','=',False)]}"
+                            invisible="not assign_to_any"
                         />
                     </group>
                     <field name="change_request_id" invisible="1" />

--- a/spp_change_request_add_children_demo/models/change_request_add_children.py
+++ b/spp_change_request_add_children_demo/models/change_request_add_children.py
@@ -41,7 +41,7 @@ class ChangeRequestAddChildren(models.Model):
     VALIDATION_FORM = "spp_change_request_add_children_demo.view_change_request_add_children_validation_form"
     REQUIRED_DOCUMENT_TYPE = [
         # "spp_change_request_add_children_demo.spp_dms_add_children",
-        "spp_change_request_add_children_demo.spp_dms_birth_certificate",
+        # "spp_change_request_add_children_demo.spp_dms_birth_certificate",
         # "spp_change_request_add_children_demo.spp_dms_applicant_spp_card",
         # "spp_change_request_add_children_demo.spp_dms_applicant_uid_card",
         # "spp_change_request_add_children_demo.spp_dms_custody_certificate",
@@ -51,6 +51,10 @@ class ChangeRequestAddChildren(models.Model):
     # If validators will be allowed for both, make the values the same
     SRC_AREA_FLD = ["registrant_id", "area_center_id"]
     DST_AREA_FLD = SRC_AREA_FLD
+
+    def _get_dynamic_selection(self):
+        options = self.env["gender.type"].search([])
+        return [(option.value, option.code) for option in options]
 
     # Redefine registrant_id to set specific domain and label
     registrant_id = fields.Many2one(
@@ -73,9 +77,7 @@ class ChangeRequestAddChildren(models.Model):
     birth_place = fields.Char()
     birthdate_not_exact = fields.Boolean()
     birthdate = fields.Date("Date of Birth")
-    gender = fields.Selection(
-        [("Female", "Female"), ("Male", "Male")],
-    )
+    gender = fields.Selection(selection=_get_dynamic_selection)
     phone = fields.Char("Phone Number")
     uid_number = fields.Char("UID Number")
 

--- a/spp_change_request_add_children_demo/views/change_request_add_children_view.xml
+++ b/spp_change_request_add_children_demo/views/change_request_add_children_view.xml
@@ -191,7 +191,7 @@
                                 <field name="applicant_relation" readonly="state != 'draft'" />
                             </group>
                         </page>
-                        <page string="Attachments">
+                        <page string="Attachments" invisible="1">
                             <!-- Attachment UI -->
                             <header invisible="state != 'draft'">
                                 <!-- <button

--- a/spp_change_request_add_children_demo/views/change_request_add_children_view.xml
+++ b/spp_change_request_add_children_demo/views/change_request_add_children_view.xml
@@ -46,7 +46,7 @@
                         string="Request Validation"
                         icon="fa-paper-plane"
                         class="btn-primary"
-                        states="draft"
+                        invisible="state != 'draft'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_agent"
                     />
                     <button
@@ -55,7 +55,7 @@
                         string="Validate"
                         icon="fa-check-square-o"
                         class="btn-warning"
-                        states="pending"
+                        invisible="state != 'pending'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_validator,spp_change_request.group_spp_change_request_hq_validator"
                     />
                     <button
@@ -64,7 +64,7 @@
                         string="Apply Changes"
                         icon="fa-thumbs-o-up"
                         class="btn-success"
-                        states="validated"
+                        invisible="state != 'validated'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_applicator"
                     />
                     <button
@@ -73,7 +73,7 @@
                         string="Reject"
                         icon="fa-ban"
                         class="btn-danger"
-                        states="pending"
+                        invisible="state != 'pending'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_validator,spp_change_request.group_spp_change_request_hq_validator"
                     />
                     <button
@@ -82,7 +82,7 @@
                         string="Cancel Change Request"
                         icon="fa-times-circle"
                         class="btn-default"
-                        states="draft,pending,rejected,validated"
+                        invisible="state not in ['draft', 'pending', 'rejected', 'validated']"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_agent"
                     />
                     <button
@@ -91,7 +91,7 @@
                         string="Reset to Draft"
                         icon="fa-rotate-left"
                         class="btn-success"
-                        states="rejected"
+                        invisible="state != 'rejected'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_agent"
                     />
                     <field
@@ -107,7 +107,7 @@
                             type="object"
                             icon="fa-user-circle"
                             class="oe_stat_button"
-                            states="pending,validated"
+                            invisible="state not in ['pending', 'validated']"
                             groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_validator,spp_change_request.group_spp_change_request_applicator"
                         >
                             <div class="o_form_field o_stat_info">
@@ -131,7 +131,7 @@
                                 icon="fa-external-link "
                                 class="btn-success"
                                 style="margin-left: 10px;"
-                                attrs="{'invisible':[('registrant_id','=',False)]}"
+                                invisible="not registrant_id"
                             />
                         </h1>
                         <label for="applicant_id" string="Applicant:" />
@@ -148,7 +148,7 @@
                                 icon="fa-external-link "
                                 class="btn-success"
                                 style="margin-left: 10px;"
-                                attrs="{'invisible':[('registrant_id','=',False)]}"
+                                invisible="not registrant_id"
                             />
                         </h2>
                         <div class="o_row">
@@ -160,63 +160,40 @@
                     </div>
                     <notebook>
                         <page string="Request Details">
-                            <field
+                            <!-- widget is currently not working -->
+                            <!-- <field
                                 name="id_document_details"
                                 widget="id_document_reader_field"
                                 colspan="4"
-                                attrs="{'invisible':[('state','!=','draft')]}"
-                            />
+                                invisible="state != 'draft'"
+                            /> -->
                             <group colspan="4" col="4" string="">
                                 <field name="full_name" readonly="1" colspan="4" class="oe_read_only" />
                                 <field
                                     name="family_name"
-                                    attrs="{'readonly':[('state','!=','draft')]}"
+                                    readonly="state != 'draft'"
                                     class="oe_edit_only"
                                     colspan="4"
                                 />
-                                <field
-                                    name="given_name"
-                                    attrs="{'readonly':[('state','!=','draft')]}"
-                                    class="oe_edit_only"
-                                />
-                                <field
-                                    name="addl_name"
-                                    attrs="{'readonly':[('state','!=','draft')]}"
-                                    class="oe_edit_only"
-                                />
-                                <field name="gender" attrs="{'readonly':[('state','!=','draft')]}" />
+                                <field name="given_name" readonly="state != 'draft'" class="oe_edit_only" />
+                                <field name="addl_name" readonly="state != 'draft'" class="oe_edit_only" />
+                                <field name="gender" readonly="state != 'draft'" />
                                 <field
                                     name="phone"
-                                    attrs="{'readonly':[('state','!=','draft')]}"
+                                    readonly="state != 'draft'"
                                     widget="phone"
                                     options="{'enable_sms': false}"
                                 />
-                                <field name="uid_number" attrs="{'readonly':[('state','!=','draft')]}" />
-                                <field
-                                    name="birth_place"
-                                    colspan="4"
-                                    attrs="{'readonly':[('state','!=','draft')]}"
-                                />
-                                <field
-                                    name="birthdate_not_exact"
-                                    attrs="{'readonly':[('state','!=','draft')]}"
-                                />
-                                <field name="birthdate" attrs="{'readonly':[('state','!=','draft')]}" />
-                                <!-- <field
-                                    name="kind"
-                                    widget="many2many_tags"
-                                    options="{'no_open':True, 'no_create_edit':True, 'no_create':True, 'no_quick_create':True}"
-                                    attrs="{'readonly':[('state','!=','draft')]}"
-                                /> -->
-                                <field
-                                    name="applicant_relation"
-                                    attrs="{'readonly':[('state','!=','draft')]}"
-                                />
+                                <field name="uid_number" readonly="state != 'draft'" />
+                                <field name="birth_place" readonly="state != 'draft'" />
+                                <field name="birthdate_not_exact" readonly="state != 'draft'" />
+                                <field name="birthdate" readonly="state != 'draft'" />
+                                <field name="applicant_relation" readonly="state != 'draft'" />
                             </group>
                         </page>
                         <page string="Attachments">
                             <!-- Attachment UI -->
-                            <header attrs="{'invisible':[('state','!=','draft')]}">
+                            <header invisible="state != 'draft'">
                                 <!-- <button
                                     name="action_attach_documents"
                                     type="object"
@@ -233,23 +210,6 @@
                                     context="{'category_id':%(spp_dms_birth_certificate)d}"
                                     style="margin-left: 10px;"
                                 />
-                                <!-- <button
-                                    name="action_attach_documents"
-                                    type="object"
-                                    string="Applicant UID Card"
-                                    class="btn-primary"
-                                    context="{'category_id':%(spp_dms_applicant_uid_card)d}"
-                                    style="margin-left: 10px;"
-                                />
-                                <button
-                                    name="action_attach_documents"
-                                    type="object"
-                                    string="Custody Certificate"
-                                    class="btn-primary"
-                                    context="{'category_id':%(spp_dms_custody_certificate)d}"
-                                    style="margin-left: 10px;"
-                                    attrs="{'invisible':[('applicant_relation','not in',('mother','grandfather'))]}"
-                                /> -->
                                 <button
                                     name="action_attach_documents"
                                     type="object"
@@ -260,7 +220,7 @@
                             </header>
                             <field
                                 name="dms_file_ids"
-                                attrs="{'readonly':[('state','!=','draft')]}"
+                                readonly="state != 'draft'"
                                 nolabel="1"
                                 context="{'form_view_ref':'spp_change_request.view_dms_file_spp_custom_form'}"
                             >
@@ -271,7 +231,7 @@
                                     multi_edit="1"
                                     create="0"
                                 >
-                                    <field name="name" invisible="1" />
+                                    <field name="name" column_invisible="1" />
                                     <field
                                         name="content"
                                         filename="name"
@@ -284,26 +244,21 @@
                                     <field name="mimetype" />
                                     <field name="size" widget="integer" />
                                     <field name="write_date" />
-                                    <field name="active" invisible="1" />
-                                    <field name="is_locked" invisible="1" />
-                                    <field name="is_lock_editor" invisible="1" />
+                                    <field name="active" column_invisible="1" />
+                                    <field name="is_locked" column_invisible="1" />
+                                    <field name="is_lock_editor" column_invisible="1" />
                                 </tree>
                             </field>
-                            <!-- <field
-                                name="dms_directory_ids"
-                                mode="dms_tree"
-                                attrs="{'invisible':[('registrant_id','=',False)],'readonly':[('state','!=','draft')]}"
-                            /> -->
                         </page>
                         <page string="Validation Sequence" groups="g2p_registry_base.group_g2p_admin">
                             <field
                                 name="validation_ids"
                                 nolabel="1"
-                                attrs="{'readonly':[('state','not in',('draft','pending'))]}"
+                                readonly="state not in ('draft','pending')"
                             >
                                 <tree>
                                     <field name="sequence" widget="handle" />
-                                    <field name="request_type" invisible="1" />
+                                    <field name="request_type" column_invisible="1" />
                                     <field name="stage_id" options="{'no_create_edit':true}" />
                                     <field
                                         name="validation_group_id"
@@ -334,8 +289,7 @@
                                     required="1"
                                     widget="phone"
                                     options="{'enable_sms': false}"
-                                    attrs="{'readonly':[('state','!=','draft')]}"
-                                    readonly="1"
+                                    readonly="state != 'draft'"
                                     colspan="4"
                                 />
                                 <field name="last_validated_by_id" readonly="1" />
@@ -363,7 +317,7 @@
                         icon="fa-user-circle"
                         class="btn-primary"
                         string="Assign To Me"
-                        attrs="{'invisible': ['|',('current_user_assigned', '!=', False), ('state', 'not in', ('draft', 'pending','validated', 'rejected'))]}"
+                        invisible="current_user_assigned or state not in ('draft', 'pending','validated', 'rejected')"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_validator,spp_change_request.group_spp_change_request_applicator"
                     />
                     <button
@@ -372,7 +326,7 @@
                         icon="fa-user-circle"
                         class="btn-primary"
                         string="Reassign"
-                        attrs="{'invisible': ['|',('current_user_assigned', '!=', True), ('state', 'not in', ('pending','validated'))]}"
+                        invisible="not current_user_assigned or state not in ('pending','validated')"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_validator,spp_change_request.group_spp_change_request_applicator"
                     />
                     <button
@@ -381,7 +335,7 @@
                         string="Request Validation"
                         icon="fa-paper-plane"
                         class="btn-primary"
-                        states="draft"
+                        invisible="state != 'draft'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_agent"
                     />
                     <button
@@ -390,7 +344,7 @@
                         string="Validate"
                         icon="fa-check-square-o"
                         class="btn-warning"
-                        states="pending"
+                        invisible="state != 'pending'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_validator,spp_change_request.group_spp_change_request_hq_validator"
                     />
                     <button
@@ -399,7 +353,7 @@
                         string="Apply Changes"
                         icon="fa-thumbs-o-up"
                         class="btn-success"
-                        states="validated"
+                        invisible="state != 'validated'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_applicator"
                     />
                     <button
@@ -408,7 +362,7 @@
                         string="Reject"
                         icon="fa-ban"
                         class="btn-danger"
-                        states="pending"
+                        invisible="state != 'pending'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_validator,spp_change_request.group_spp_change_request_hq_validator"
                     />
                     <button
@@ -417,7 +371,7 @@
                         string="Cancel Change Request"
                         icon="fa-times-circle"
                         class="btn-default"
-                        states="draft,pending,rejected,validated"
+                        invisible="state not in ['draft', 'pending', 'rejected', 'validated']"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_agent"
                     />
                     <button
@@ -426,7 +380,7 @@
                         string="Reset to Draft"
                         icon="fa-rotate-left"
                         class="btn-success"
-                        states="rejected"
+                        invisible="state != 'rejected'"
                         groups="g2p_registry_base.group_g2p_admin,spp_change_request.group_spp_change_request_administrator,spp_change_request.group_spp_change_request_agent"
                     />
                     <field
@@ -452,7 +406,7 @@
                                     icon="fa-external-link "
                                     class="btn-success"
                                     style="margin-left: 10px;"
-                                    attrs="{'invisible':[('registrant_id','=',False)]}"
+                                    invisible="not registrant_id"
                                 />
                             </h2>
                         </div>
@@ -542,7 +496,7 @@
                                         type="object"
                                         icon="fa-external-link"
                                         class="btn-success"
-                                        attrs="{'invisible':[('applicant_id','=',False)]}"
+                                        invisible="not applicant_id"
                                         style="margin-left: 10px;"
                                         colspan="2"
                                     />
@@ -593,7 +547,7 @@
                                         multi_edit="1"
                                         create="0"
                                     >
-                                        <field name="name" invisible="1" />
+                                        <field name="name" column_invisible="1" />
                                         <field
                                             name="content"
                                             filename="name"
@@ -603,19 +557,14 @@
                                         />
                                         <field name="category_id" />
                                         <field name="directory_id" />
-                                        <field name="mimetype" invisible="1" />
+                                        <field name="mimetype" column_invisible="1" />
                                         <field name="size" widget="integer" />
                                         <field name="write_date" />
-                                        <field name="active" invisible="1" />
-                                        <field name="is_locked" invisible="1" />
-                                        <field name="is_lock_editor" invisible="1" />
+                                        <field name="active" column_invisible="1" />
+                                        <field name="is_locked" column_invisible="1" />
+                                        <field name="is_lock_editor" column_invisible="1" />
                                     </tree>
                                 </field>
-                                <!-- <field
-                                    name="dms_directory_ids"
-                                    mode="dms_tree"
-                                    attrs="{'readonly':[('state','!=','draft')]}"
-                                /> -->
                             </page>
                             <page string="Other Information">
                                 <group colspan="4" col="4">

--- a/theme_openspp/__manifest__.py
+++ b/theme_openspp/__manifest__.py
@@ -19,9 +19,10 @@
         "web.assets_backend": [
             "theme_openspp/static/src/scss/assets_backend.scss",
             "theme_openspp/static/src/scss/dynamic_dasbhoard.scss",
-            "theme_openspp/static/src/js/basic_fields.js",
-            "theme_openspp/static/src/js/user_menu_items.esm.js",
-            "theme_openspp/static/src/js/app_window_title.js",
+            # deprecated javascript class/function, need to find a way to fix this
+            # "theme_openspp/static/src/js/basic_fields.js",
+            # "theme_openspp/static/src/js/user_menu_items.esm.js",
+            # "theme_openspp/static/src/js/app_window_title.js",
         ],
     },
     "application": True,

--- a/theme_openspp/models/base.py
+++ b/theme_openspp/models/base.py
@@ -5,8 +5,8 @@ class Base(models.AbstractModel):
     _inherit = "base"
 
     @api.model
-    def search(self, domain, offset=0, limit=None, order=None, count=False):
-        res = super().search(domain, offset, limit, order, count)
-        if not count and self._name == "payment.acquirer":
+    def search(self, domain, offset=0, limit=None, order=None):
+        res = super().search(domain, offset, limit, order)
+        if self._name == "payment.acquirer":
             res = res.filtered(lambda a: not a.module_to_buy)
         return res

--- a/theme_openspp/models/ir_module_module.py
+++ b/theme_openspp/models/ir_module_module.py
@@ -5,6 +5,6 @@ class IrModuleModule(models.Model):
     _inherit = "ir.module.module"
 
     @api.model
-    def search(self, domain, offset=0, limit=None, order=None, count=False):
+    def search(self, domain, offset=0, limit=None, order=None):
         domain += [("to_buy", "=", False)]
-        return super().search(domain, offset, limit, order, count)
+        return super().search(domain, offset, limit, order)

--- a/theme_openspp/models/ir_ui_view.py
+++ b/theme_openspp/models/ir_ui_view.py
@@ -8,7 +8,7 @@ _logger = logging.getLogger(__name__)
 class View(models.Model):
     _inherit = "ir.ui.view"
 
-    def _render_template(self, template, values=None, engine="ir.qweb"):
+    def _render_template(self, template, values=None):
         # if template in ['web.login', 'web.webclient_bootstrap']:
         if not values:
             values = {}
@@ -17,4 +17,4 @@ class View(models.Model):
             .sudo()
             .get_param("app_system_name", "OpenSPP")
         )
-        return super()._render_template(template, values=values, engine=engine)
+        return super()._render_template(template, values=values)

--- a/theme_openspp/models/res_config_settings.py
+++ b/theme_openspp/models/res_config_settings.py
@@ -1,28 +1,30 @@
-from lxml import etree
-
-from odoo import api, models
+from odoo import models
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
-    @api.model
-    def fields_view_get(
-        self, view_id=None, view_type="form", toolbar=False, submenu=False
-    ):
-        ret_val = super().fields_view_get(
-            view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
-        )
+    # fields_view_get replaced as _get_view with a different return value
+    # need to fix this.
 
-        page_name = ret_val["name"]
-        if not page_name == "res.config.settings.view.form":
-            return ret_val
+    # @api.model
+    # def _get_view(
+    #     self, view_id=None, view_type="form", **options
+    # ):
+    #     arch, view = super()._get_view(
+    #         view_id, view_type, **options
+    #     )
 
-        doc = etree.XML(ret_val["arch"])
+    #     page_name = view["name"]
+    #     if not page_name == "res.config.settings.view.form":
+    #         return arch, view
 
-        query = "//div[div[field[@widget='upgrade_boolean']]]"
-        for item in doc.xpath(query):
-            item.attrib["class"] = "d-none"
+    #     doc = arch
 
-        ret_val["arch"] = etree.tostring(doc)
-        return ret_val
+    #     query = "//div[div[field[@widget='upgrade_boolean']]]"
+    #     for item in doc.xpath(query):
+    #         item.attrib["class"] = "d-none"
+
+    #     arch = etree.tostring(doc)
+
+    #     return arch, view

--- a/theme_openspp/views/ir_ui_menu.xml
+++ b/theme_openspp/views/ir_ui_menu.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
-    <record id="base.menu_module_updates" model="ir.ui.menu">
+    <!-- <record id="base.menu_module_updates" model="ir.ui.menu">
         <field name="parent_id" ref="base.menu_ir_property" />
-    </record>
-    <record id="base.module_mi" model="ir.ui.menu">
+    </record> -->
+    <!-- <record id="base.module_mi" model="ir.ui.menu">
         <field name="parent_id" ref="base.menu_ir_property" />
-    </record>
+    </record> -->
     <record id="base.menu_theme_store" model="ir.ui.menu">
         <field name="parent_id" ref="base.menu_ir_property" />
     </record>

--- a/theme_openspp/views/res_config_settings_views.xml
+++ b/theme_openspp/views/res_config_settings_views.xml
@@ -4,7 +4,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='appstore']" position="attributes">
+            <xpath expr="//setting[@id='appstore']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
         </field>


### PR DESCRIPTION
3 modules migrated to 17.0. Separated by commit messages.

- spp_change_request
-> Migration to 17.0
-> Javascript not working because of a removed javascript function in odoo 17, need to fix this

- spp_change_request_add_children_demo
-> Migration to 17.0
-> Javascript not working because of a removed javascript function in odoo 17, need to fix this
-> Removed Birth Certificate as required document (for now)
-> gender Selection field's value changed to dynamic

- theme_openspp
-> Migration to 17.0
-> Javascript not working because of a removed javascript function in odoo 17, need to fix this
-> Removed excess parameters in search function and _render_template function
-> Commented theme_openspp/models/res_config_settings.py (for now) since fields_view_get now have different return values.
-> Commented "base.menu_module_updates" and "base.module_mi" since they are already deleted in odoo 17
-> 