### PR TITLE
fix marital status and add married in the selection on base

### DIFF
--- a/spp_farmer_registry_base/models/farmer.py
+++ b/spp_farmer_registry_base/models/farmer.py
@@ -13,6 +13,7 @@ class Farmer(models.Model):
         [
             ("single", "Single"),
             ("widowed", "Widowed"),
+            ("married", "Married"),
             ("separated", "Separated"),
         ],
         string="Marital Status",
@@ -59,6 +60,7 @@ class TempFarmer(models.Model):
     farmer_marital_status = fields.Selection(
         [
             ("single", "Single"),
+            ("married", "Married"),
             ("widowed", "Widowed"),
             ("separated", "Separated"),
         ],

--- a/spp_farmer_registry_demo/models/farmer.py
+++ b/spp_farmer_registry_demo/models/farmer.py
@@ -5,13 +5,10 @@ class Farmer(models.Model):
     _inherit = "res.partner"
 
     marital_status = fields.Selection(
-        [
-            ("single", "Single"),
+        selection_add=[
             ("married_monogamous", "Married Monogamous"),
             ("married_polygamous", "Married Polygamous"),
-            ("widowed", "Widowed"),
-            ("separated", "Separated"),
-        ],
+        ]
     )
     highest_education_level = fields.Selection(
         [
@@ -23,4 +20,15 @@ class Farmer(models.Model):
             ("university", "University"),
             ("tertiary", "Tertiary"),
         ],
+    )
+
+
+class TempFarmer(models.Model):
+    _inherit = "spp.farmer"
+
+    farmer_marital_status = fields.Selection(
+        selection_add=[
+            ("married_monogamous", "Married Monogamous"),
+            ("married_polygamous", "Married Polygamous"),
+        ]
     )

--- a/spp_farmer_registry_demo/models/generate_farmer_data.py
+++ b/spp_farmer_registry_demo/models/generate_farmer_data.py
@@ -160,6 +160,7 @@ class SPPGenerateFarmerData(models.Model):
 
         marital_status = [
             "single",
+            "married",
             "married_monogamous",
             "married_polygamous",
             "widowed",


### PR DESCRIPTION
- Set marital status fields in spp_farmer_registry_base to Single, Married, Widowed, Separated. 
- Add in spp_farmer_registry_demo the marital status: Married Monogamous and Married Polygamous
- Modify the demo data generator to support the marital status above.