### PR TITLE
ci: Add gitleaks to the pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,3 +143,7 @@ repos:
       - id: pylint_odoo
         args:
           - --rcfile=.pylintrc-mandatory
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.18.2
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
ci: Add gitleaks to the pre-commit hook
Task assigned [here](https://github.com/OpenSPP/openspp-modules).