### PR TITLE
Removing tests from pip installed dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,9 +116,13 @@ jobs:
         continue-on-error: true
       - name: Initialize test db
         run: oca_init_test_database
+      - name: Remove test files from pip-installed addons
+        run: |
+          rm -rf /opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/g2p_programs/tests
+          rm -rf /opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/g2p_registry_individual/tests
       - name: Run tests
         env:
-          EXCLUDE: "g2p_bank,g2p_entitlement_differential,g2p_entitlement_in_kind,g2p_entitlement_voucher,g2p_payment_cash,g2p_payment_files,g2p_payment_g2p_connect,g2p_payment_interop_layer,g2p_payment_phee,g2p_payment_simple_mpesa,g2p_program_approval,g2p_program_assessment,g2p_program_autoenrol,g2p_program_cycleless,g2p_program_documents,g2p_program_registrant_info,g2p_program_reimbursement,g2p_programs,g2p_proxy_means_test,g2p_registry_addl_info,g2p_registry_base,g2p_registry_group,g2p_registry_individual,g2p_registry_membership,muk_product,muk_web_appsbar,muk_web_chatter,muk_web_colors,muk_web_dialog,muk_web_theme,g2p_openid_vci_rest_api,g2p_openid_vci,g2p_registry_encryption"
+          EXCLUDE: "g2p_bank,g2p_entitlement_differential,g2p_entitlement_in_kind,g2p_entitlement_voucher,g2p_payment_cash,g2p_payment_files,g2p_payment_g2p_connect,g2p_payment_interop_layer,g2p_payment_phee,g2p_payment_simple_mpesa,g2p_program_approval,g2p_program_assessment,g2p_program_autoenrol,g2p_program_cycleless,g2p_program_documents,g2p_program_registrant_info,g2p_program_reimbursement,g2p_programs,g2p_proxy_means_test,g2p_registry_addl_info,g2p_registry_base,g2p_registry_group,g2p_registry_individual,g2p_registry_membership,muk_product,muk_web_appsbar,muk_web_chatter,muk_web_colors,muk_web_dialog,muk_web_theme,g2p_openid_vci_rest_api,g2p_openid_vci,g2p_registry_encryption,g2p_encryption,g2p_encryption_keymanager"
         run: oca_run_tests
       - uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
This is to avoid them running with the OpenSPP GH action