### PR TITLE
Fix issue of approving In-kind Entitlement

### DIFF
--- a/spp_programs/models/stock/stock.py
+++ b/spp_programs/models/stock/stock.py
@@ -24,9 +24,9 @@ class StockMove(models.Model):
             picking_id = self.mapped("picking_id")
             entitlement_ids = self.mapped("entitlement_id.cycle_id")
             for entitlement_id in entitlement_ids:
-                picking_id.message_post_with_view(
+                picking_id.message_post_with_source(
                     "mail.message_origin_link",
-                    values={"self": picking_id, "origin": entitlement_id},
+                    render_values={"self": picking_id, "origin": entitlement_id},
                     subtype_id=self.env.ref("mail.mt_note").id,
                 )
         return


### PR DESCRIPTION
While approving the In-kind entitlement it has an error 

`AttributeError: 'stock.picking' object has no attribute 'message_post_with_view'`

Method `message_post_with_view` is deprecated in `mail.thread` model in odoo17 and has been replaced with `message_post_with_source` method.