### PR TITLE
display programs in service point form and tree view

### DIFF
--- a/spp_programs_sp/__manifest__.py
+++ b/spp_programs_sp/__manifest__.py
@@ -21,6 +21,7 @@
         "wizard/create_program_wizard.xml",
         "views/programs_view.xml",
         "views/entitlements_view.xml",
+        "views/service_point_views.xml",
     ],
     "assets": {},
     "demo": [],

--- a/spp_programs_sp/models/__init__.py
+++ b/spp_programs_sp/models/__init__.py
@@ -6,3 +6,4 @@ from . import entitlement_inkind
 from . import entitlement_manager_default
 from . import entitlement_manager_cash
 from . import entitlement_manager_inkind
+from . import service_point

--- a/spp_programs_sp/models/entitlement_cash.py
+++ b/spp_programs_sp/models/entitlement_cash.py
@@ -14,5 +14,11 @@ class CustomSPPProgramEntitlementCash(models.Model):
 
     _inherit = "g2p.entitlement"
 
-    service_point_ids = fields.Many2many("spp.service.point", string="Service Points")
+    service_point_ids = fields.Many2many(
+        comodel_name="spp.service.point",
+        relation="g2p_entitlement_spp_service_point_rel",
+        column1="g2p_entitlement_id",
+        column2="spp_service_point_id",
+        string="Service Points",
+    )
     service_point_id = fields.Many2one("spp.service.point", "Service Point")

--- a/spp_programs_sp/models/service_point.py
+++ b/spp_programs_sp/models/service_point.py
@@ -1,0 +1,22 @@
+from odoo import _, fields, models
+
+
+class CustomOpenSPPServicePoint(models.Model):
+    _inherit = "spp.service.point"
+
+    g2p_entitlement_ids = fields.Many2many(
+        comodel_name="g2p.entitlement",
+        relation="g2p_entitlement_spp_service_point_rel",
+        column1="spp_service_point_id",
+        column2="g2p_entitlement_id",
+        string=_("G2P Entitlements"),
+    )
+
+    program_ids = fields.One2many(
+        "g2p.program",
+        compute="_compute_program_ids",
+    )
+
+    def _compute_program_ids(self):
+        for rec in self:
+            rec.program_ids = rec.g2p_entitlement_ids.mapped("program_id")

--- a/spp_programs_sp/views/service_point_views.xml
+++ b/spp_programs_sp/views/service_point_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_service_points_tree_inherit_spp_registrant_import" model="ir.ui.view">
+        <field name="name">spp.service.point.view.list.inherit</field>
+        <field name="model">spp.service.point</field>
+        <field name="inherit_id" ref="spp_service_points.view_service_points_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='is_disabled']" position="after">
+                <field name="program_ids" widget="many2many_tags" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="custom_service_points_form_inherit" model="ir.ui.view">
+        <field name="name">custom_service_points_form_inherit</field>
+        <field name="model">spp.service.point</field>
+        <field name="inherit_id" ref="spp_service_points.view_service_points_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='service_type_ids']" position="before">
+                <field name="program_ids" widget="many2many_tags" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Why is this change needed?

Programs is not displayed in the Service point form view and tree view.

## How was the change implemented?

Created a computed field in service point that gets the program ids of the entitlements of service point then add it in the tree and form view of service point.

## How to test manually...
- Install the modules `spp_programs_sp`
- Assign a Service Point to a Group.
- Create Program with Group type.
- Tick Store Service Points to Entitlements checkbox in Entitlement Manager.
- Create Cycle then Prepare Entitlement.
- Click Entitlements and check if Service Point is assigned to Group in Step 1.
- Go to Service Point page.
- Check if the Program created is under the Service Point assigned.

## Links
- https://github.com/OpenSPP/openspp-modules/issues/443

