### PR TITLE
manual eligibility fixes

### DIFF
--- a/spp_manual_eligibility/views/program_view.xml
+++ b/spp_manual_eligibility/views/program_view.xml
@@ -9,8 +9,13 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
         <field name="priority">1010</field>
         <field name="inherit_id" ref="g2p_programs.view_program_list_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='date_ended']" position="after">
+            <xpath expr="//field[@name='target_type']" position="after">
                 <field name="is_manual_eligibility" invisible="1" />
+            </xpath>
+            <xpath expr="//button[@name='verify_eligibility']" position="attributes">
+                <attribute name="invisible">
+                    is_manual_eligibility or state != 'active'
+                </attribute>
             </xpath>
         </field>
     </record>
@@ -23,9 +28,46 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
         <field name="arch" type="xml">
             <xpath expr="//button[@name='import_eligible_registrants']" position="attributes">
                 <attribute name="invisible">
+                    is_manual_eligibility or state != 'active'
+                </attribute>
+            </xpath>
+            <xpath expr="//button[@name='enroll_eligible_registrants']" position="attributes">
+                <attribute name="invisible">
+                    is_manual_eligibility or state != 'active'
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_eligibility_manager_default_form_manual_eligibility" model="ir.ui.view">
+        <field name="name">view_eligibility_manager_default_form_manual_eligibility</field>
+        <field name="model">g2p.program_membership.manager.default</field>
+        <field name="priority">1010</field>
+        <field name="inherit_id" ref="g2p_programs.view_eligibility_manager_default_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='eligibility_domain']" position="after">
+                <field name="is_manual_eligibility" invisible="1" />
+            </xpath>
+            <xpath expr="//field[@name='eligibility_domain']" position="attributes">
+                <attribute name="invisible">
                     is_manual_eligibility
                 </attribute>
             </xpath>
         </field>
     </record>
+
+    <record id="view_eligibility_manager_default_form_spp_manual" model="ir.ui.view">
+        <field name="name">view_eligibility_manager_default_form_spp_manual</field>
+        <field name="model">g2p.program_membership.manager.default</field>
+        <field name="priority">1010</field>
+        <field name="inherit_id" ref="spp_programs.view_eligibility_manager_default_form_spp" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='admin_area_ids']" position="attributes">
+                <attribute name="invisible">
+                    is_manual_eligibility
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>

--- a/spp_manual_eligibility/wizard/__init__.py
+++ b/spp_manual_eligibility/wizard/__init__.py
@@ -1,3 +1,4 @@
 # Part of OpenG2P. See LICENSE file for full copyright and licensing details.
 
 from . import create_program_wizard
+from . import assign_to_program_wizard

--- a/spp_manual_eligibility/wizard/assign_to_program_wizard.py
+++ b/spp_manual_eligibility/wizard/assign_to_program_wizard.py
@@ -1,0 +1,24 @@
+# Part of OpenG2P. See LICENSE file for full copyright and licensing details.
+import logging
+
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class G2PAssignToProgramWizard(models.TransientModel):
+    _inherit = "g2p.assign.program.wizard"
+
+    def assign_registrant(self):
+        vals = super().assign_registrant()
+        for rec in self:
+            if rec.program_id and rec.program_id.is_manual_eligibility:
+                for beneficiary in rec.program_id.program_membership_ids:
+                    if not beneficiary.state == "enrolled":
+                        beneficiary.write(
+                            {
+                                "state": "enrolled",
+                                "enrollment_date": fields.Datetime.now(),
+                            }
+                        )
+        return vals


### PR DESCRIPTION
- Auto enroll registrants when adding to a program where the eligibility manager is set to Manual Eligibility
- Hide Enroll Eligible Beneficiaries, Import Eligible Beneficiaries and Verify Eligibility buttons in the program's UI if the program's eligibility manager is set to Manual Eligibility
- Hide the domain and area fields in the Eligibility Manager's UI if the eligibility manager is set to Manual Eligibility