### PR TITLE
Fixed duplicate checkbox in the additional details; added test case

### DIFF
--- a/spp_custom_field/models/cus_partner.py
+++ b/spp_custom_field/models/cus_partner.py
@@ -28,9 +28,6 @@ class OpenSPPResPartner(models.Model):
             sub_element_params = {
                 "name": model_field_id.name,
             }
-            if is_ind:
-                sub_element_params["readonly"] = "1"
-                sub_element_params["class"] = "oe_read_only"
             new_field = etree.SubElement(
                 div_element_left,
                 "field",
@@ -41,9 +38,6 @@ class OpenSPPResPartner(models.Model):
                 div_element_right_help = etree.SubElement(div_element_right, "div", {"class": "text-muted"})
                 span = etree.SubElement(div_element_right_help, "span")
                 span.text = model_field_id.help
-
-            div_element_right_inner_div = etree.SubElement(div_element_right, "div", {"class": "text-muted"})
-            new_field = etree.SubElement(div_element_right_inner_div, "field", {"name": model_field_id.name})
 
         else:
             etree.SubElement(div_element_right, "label", {"for": model_field_id.name})
@@ -82,8 +76,8 @@ class OpenSPPResPartner(models.Model):
                     action_id = action_id.context.replace("'", '"')
                 is_group = ast.literal_eval(action_id).get("default_is_group")
 
-                custom_page = etree.Element("page", {"string": "Additional Details"})
-                indicators_page = etree.Element("page", {"string": "Indicators"})
+                custom_page = etree.Element("page", {"string": "Additional Details", "name": "additional_details"})
+                indicators_page = etree.Element("page", {"string": "Indicators", "name": "indicators"})
 
                 custom_div = etree.SubElement(custom_page, "div", {"class": "row mt16 o_settings_container"})
                 indicators_div = etree.SubElement(indicators_page, "div", {"class": "row mt16 o_settings_container"})

--- a/spp_demo/tests/__init__.py
+++ b/spp_demo/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_cus_partner

--- a/spp_demo/tests/test_cus_partner.py
+++ b/spp_demo/tests/test_cus_partner.py
@@ -1,0 +1,32 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestOpenSPPResPartnerCustom(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.view_group_id = cls.env.ref("g2p_registry_group.view_groups_form").id
+        cls.view_group_action_id = cls.env.ref("g2p_registry_group.action_groups_list").id
+
+        cls.view_individual_id = cls.env.ref("g2p_registry_individual.view_individuals_form").id
+        cls.view_individual_action_id = cls.env.ref("g2p_registry_individual.action_individuals_list").id
+
+    def test_get_view_group(self):
+        options = {"action_id": self.view_group_action_id, "load_filters": True, "toolbar": True}
+        arch, view = self.env["res.partner"]._get_view(self.view_group_id, "form", **options)
+
+        self.assertEqual(len(arch.xpath("//page[@name='indicators']")), 1)
+        self.assertEqual(len(arch.xpath("//page[@name='additional_details']")), 0)
+
+    def test_get_view_individual(self):
+        options = {"action_id": self.view_individual_action_id, "load_filters": True, "toolbar": True}
+        arch, view = self.env["res.partner"]._get_view(self.view_individual_id, "form", **options)
+
+        self.assertEqual(len(arch.xpath("//page[@name='indicators']")), 0)
+        self.assertEqual(len(arch.xpath("//page[@name='additional_details']")), 1)
+
+    def test_get_view_no_options(self):
+        arch, view = self.env["res.partner"]._get_view(self.view_individual_id, "form")
+
+        self.assertEqual(len(arch.xpath("//page[@name='indicators']")), 0)
+        self.assertEqual(len(arch.xpath("//page[@name='additional_details']")), 1)


### PR DESCRIPTION
## Why is this change needed?

There are two checkbox existing per boolean fields in the `Additional Details` of the individual Registry

## How was the change implemented?

Removed the creation of the additional checkbox in the function `create_field_element`.

## New unit tests...

```
TestOpenSPPResPartnerCustom
```

## Unit tests executed by the author...

```
spp_demo/tests/test_cus_partner.py::TestOpenSPPResPartnerCustom
```

## How to test manually...
- Install the modules `spp_demo` and `spp_pmt`
- Create a record in Group and Individual Registry

Test-1
- In Group Registry, Navigate to `Indicator` Tab.
- Check if the boolean indicator fields have one checkbox.

Test-2
- In Individual Registry, Navigate to `Additional Details` Tab.
- Check if the boolean indicator fields have one checkbox.

## Links
- https://github.com/OpenSPP/openspp-acf/issues/29

