### PR TITLE
Fixed country office create button error

### DIFF
--- a/spp_base_setting/views/country_office_views.xml
+++ b/spp_base_setting/views/country_office_views.xml
@@ -62,6 +62,8 @@
                                         widget="url"
                                         placeholder="e.g. https://www.odoo.com"
                                     />
+                                    <field name="parent_id" groups="base.group_no_one" />
+                                    <field name="parent_id" invisible="1" />
                                 </group>
                                 <group name="social_media" />
                             </group>


### PR DESCRIPTION
## Why is this change needed?

There is an error when trying to create a new Country Office

## How was the change implemented?

Added the missing `parent_id` field in the xml template.

## How to test manually...
- Install the module `spp_base_setting`
- Navigate to Registry -> Configuration -> Country Office

Test-1
- Click `New` button and check if there is no error upon click it

Test-2
- Create a new country office
- Check if a new country office has been created.
