### PR TITLE
Improved the validations of the dates in cycle

### DIFF
--- a/spp_programs/models/cycle.py
+++ b/spp_programs/models/cycle.py
@@ -1,6 +1,7 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class G2PCycle(models.Model):
@@ -49,3 +50,11 @@ class G2PCycle(models.Model):
         if count:
             return self.env["g2p.cycle.membership"].search_count(domain, limit=limit)
         return self.env[entitlement_model].search(domain, offset=offset, limit=limit, order=order)
+
+    @api.constrains("start_date", "end_date")
+    def _check_dates(self):
+        for record in self:
+            if record.start_date and record.start_date < fields.Date.today():
+                raise ValidationError(_('The "Start Date" cannot be earlier than today.'))
+            if record.end_date and record.start_date and record.end_date < record.start_date:
+                raise ValidationError(_('The "End Date" cannot be earlier than the "Start Date".'))

--- a/spp_programs/tests/__init__.py
+++ b/spp_programs/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_entitlement
 from . import test_programs
 from . import test_registrant
 from . import test_stock_rule
+from . import test_cycle

--- a/spp_programs/tests/test_cycle.py
+++ b/spp_programs/tests/test_cycle.py
@@ -1,0 +1,23 @@
+from freezegun import freeze_time
+
+from odoo.exceptions import ValidationError
+
+from .common import Common
+
+
+@freeze_time("2024-07-19")
+class TestCycle(Common):
+    def test_check_dates_constrains(self):
+        with self.assertRaisesRegex(ValidationError, 'The "End Date" cannot be earlier than the "Start Date".'):
+            self.cycle.write(
+                {
+                    "end_date": "2024-07-18",
+                }
+            )
+
+        with self.assertRaisesRegex(ValidationError, 'The "Start Date" cannot be earlier than today.'):
+            self.cycle.write(
+                {
+                    "start_date": "2024-07-18",
+                }
+            )


### PR DESCRIPTION
## Why is this change needed?

To improve the validations of Start date and End date field of the cycle.

## How was the change implemented?

Added a constrains in the start_date and end_date field of g2p.cycle.

## New unit tests...

```
TestCycle
```

## Unit tests executed by the author...

```
spp_programs/tests/test_cycle.py::TestCycle
```

## How to test manually...
- Install the module `spp_programs`
- Navigate to Program.
- Create a Program.
- Create a cycle then enter the cycle created

Test-1
- Update the Start date and change its value to the date less than the current date.
- Check if an error will show.

Test-2
- Update the End date and change its value to the date less than the Start date.
- Check if an error will show.

## Links
- https://github.com/OpenSPP/openspp-acf/issues/29

