### PR TITLE
hide amount charged and value remaining in in-kind transactions

### DIFF
--- a/spp_ent_trans/views/inkind_transactions_view.xml
+++ b/spp_ent_trans/views/inkind_transactions_view.xml
@@ -23,8 +23,8 @@
                 <field name="quantity" />
                 <field name="uom_id" options="{'no_open':true,'no_create':true}" optional="hide" />
                 <field name="currency_id" options="{'no_open':true,'no_create':true}" optional="hide" />
-                <field name="amount_charged_by_service_point" column_invisible="1"/>
-                <field name="value_remaining" column_invisible="1"/>
+                <field name="amount_charged_by_service_point" column_invisible="1" />
+                <field name="value_remaining" column_invisible="1" />
             </tree>
         </field>
     </record>

--- a/spp_ent_trans/views/inkind_transactions_view.xml
+++ b/spp_ent_trans/views/inkind_transactions_view.xml
@@ -23,8 +23,8 @@
                 <field name="quantity" />
                 <field name="uom_id" options="{'no_open':true,'no_create':true}" optional="hide" />
                 <field name="currency_id" options="{'no_open':true,'no_create':true}" optional="hide" />
-                <field name="amount_charged_by_service_point" />
-                <field name="value_remaining" />
+                <field name="amount_charged_by_service_point" column_invisible="1"/>
+                <field name="value_remaining" column_invisible="1"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
## Why is this change needed?

To hide unnecessary fields (amount charged and value remaining) in the In-kind entitlement transactions.

## How was the change implemented?

Added a column_invisible attributes to the fields; amount charged and value remaining.

## New unit tests...

```
None
```

## Unit tests executed by the author...

```
None
```

## How to test manually...
- Install the module `spp_ent_trans`
- Navigate to Programs.
- Navigate to In-Kind.
- Navigate to Entitlement Transactions.
- Check if amount charged and value remaining fields is still visible.

## Links

