### PR TITLE
add string attrs for tags and kinds fields

### DIFF
--- a/spp_base/models/__init__.py
+++ b/spp_base/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import reg_id
 from . import spp_unique_id
+from . import registrant

--- a/spp_base/models/registrant.py
+++ b/spp_base/models/registrant.py
@@ -1,0 +1,13 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+import logging
+
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class OpenSPPResPartner(models.Model):
+    _inherit = "res.partner"
+
+    tags_ids = fields.Many2many("g2p.registrant.tags", string="Registrant Tags")
+    kind_as_str = fields.Char(related="kind.name", string="String Kind")


### PR DESCRIPTION
## Why is this change needed?

To avoid the duplication of fields (tags and kinds) in the custom filter when searching.

## How was the change implemented?

Added a string attributes on the (tags and kinds) fields to have a more distinguish name.

## New unit tests...

```
None
```

## Unit tests executed by the author...

```
None
```

## How to test manually...
- Install the module `spp_base`
- Navigate to Settings.
- Activate the developer mode.
- Navigate to Registry.
- Navigate to Group.
- Search with Add Custom Filter.
- In the Custom filter try to find tags or kinds.
- Make sure the tags and kinds are not duplicated on the selection.

## Links
- https://github.com/orgs/OpenSPP/projects/6/views/1?pane=issue&itemId=49381246

