### PR TITLE
Fix Unique ID UI of Area

### DIFF
--- a/spp_registrant_import/views/spp_area_views.xml
+++ b/spp_registrant_import/views/spp_area_views.xml
@@ -6,8 +6,17 @@
         <field name="model">spp.area</field>
         <field name="inherit_id" ref="spp_area.view_spparea_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='kind']" position="after">
-                <field name="spp_id" />
+            <xpath expr="//div[@name='kind']" position="after">
+                <div class="col-4 o_setting_box" name="spp_id">
+                    <div class="o_setting_left_pane">
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="spp_id" />
+                        <div>
+                        </div>
+                        <field name="spp_id" optional="show" />
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Why is this change needed?

the Unique ID of Area is not correctly displayed in the UI

## How was the change implemented?

Fix the xpath xml of the area form view.

## How to test manually...
- Install spp_area and spp_registrant_import modules.
- Go to Area and create a new Area.
- Check if the field Unique ID is correctly displayed

## Links
- https://github.com/OpenSPP/openspp-modules/issues/273