### PR TITLE
Fixed division by zero error

### DIFF
--- a/spp_pmt/models/pmt.py
+++ b/spp_pmt/models/pmt.py
@@ -76,7 +76,10 @@ class G2PGroupPMT(models.Model):
                             if hasattr(ind.individual, field):
                                 total_score += getattr(ind.individual, field) * weight
                                 total_weight += weight
-                    z_ind_grp_pmt_score = total_score / total_weight
+                    if total_weight > 0:
+                        z_ind_grp_pmt_score = total_score / total_weight
+                    else:
+                        z_ind_grp_pmt_score = 0
                 setattr(record, field_name, z_ind_grp_pmt_score)
             else:
                 setattr(record, field_name, 0)


### PR DESCRIPTION
## Why is this change needed?

Error in accessing the group registry page if weight is 0 in custom fields.

## How was the change implemented?

Added if-else statement in the computation.

## How to test manually...
- Install spp_pm.
- Go to Registry > Configuration > Custom Fields.
- Click New to create a custom field
- Populate required fields.
- make sure that `Target Type` is Individual and `With Weight` is check.
- `Default Weight` should be 0.
- Go to Group Registry, Enter a group, make sure that the group have atleast 1 member.
- Check if there is no error.

## Links
- https://github.com/OpenSPP/openspp-acf/issues/33