### PR TITLE
fix on appending data on given_name

### DIFF
--- a/spp_farmer_registry_base/__manifest__.py
+++ b/spp_farmer_registry_base/__manifest__.py
@@ -19,6 +19,7 @@
         "g2p_registry_membership",
         "spp_base_gis",
         "spp_land_record",
+        "spp_registrant_import",
     ],
     "external_dependencies": {"python": ["shapely", "geojson", "simplejson", "pyproj"]},
     "data": [

--- a/spp_farmer_registry_base/__manifest__.py
+++ b/spp_farmer_registry_base/__manifest__.py
@@ -19,7 +19,6 @@
         "g2p_registry_membership",
         "spp_base_gis",
         "spp_land_record",
-        "spp_registrant_import",
     ],
     "external_dependencies": {"python": ["shapely", "geojson", "simplejson", "pyproj"]},
     "data": [

--- a/spp_registrant_import/models/res_partner.py
+++ b/spp_registrant_import/models/res_partner.py
@@ -45,7 +45,14 @@ class Registrant(models.Model):
                 rec.given_name = name[0]
             elif len(name) == 2:
                 rec.family_name = name[0]
-                rec.given_name = name[1]
+                # Added to resolve the issue of names not from import
+                # That the given_name is appended with the addl_name
+                if rec.given_name and rec.addl_name:
+                    name_check = rec.given_name + " " + rec.addl_name
+                    if not name_check.lower() == name[1].lower():
+                        rec.given_name = name[1]
+                else:
+                    rec.given_name = name[1]
             else:
                 rec.family_name = name[0]
                 rec.given_name = name[1]


### PR DESCRIPTION
## Why is this change needed?

To Fix the given_name appending with additional_name

## How was the change implemented?

Added a check on the inverse function of name in spp_registrant_import

## New unit tests...

```
None
```

## Unit tests executed by the author...

```
None
```

## How to test manually...
- Install the module `spp_farmer_registry_base` and `spp_farmer_registry_demo`
- Navigate to Registry Group.
- Create new Group / Update existing Group.
- Fill out the Farmer in the the Farmer's Tab.
- Save and Edit again other fields to check if the Given Name doesn't append with the Additional Name.

## Links
- https://github.com/orgs/OpenSPP/projects/5/views/1?pane=issue&itemId=72329935

