### PR TITLE
fix access rights issue when applying CR

### DIFF
--- a/spp_change_request_add_children_demo/models/change_request_add_children.py
+++ b/spp_change_request_add_children_demo/models/change_request_add_children.py
@@ -260,21 +260,25 @@ class ChangeRequestAddChildren(models.Model):
             ]
         else:
             uid_rec = None
-        individual_id = self.env["res.partner"].create(
-            {
-                "is_registrant": True,
-                "is_group": False,
-                "name": self.full_name,
-                "family_name": self.family_name,
-                "given_name": self.given_name,
-                "addl_name": self.addl_name,
-                "birth_place": self.birth_place,
-                "birthdate_not_exact": self.birthdate_not_exact,
-                "birthdate": self.birthdate,
-                "gender": self.gender,
-                "phone_number_ids": phone_rec,
-                "reg_ids": uid_rec,
-            }
+        individual_id = (
+            self.env["res.partner"]
+            .sudo()
+            .create(
+                {
+                    "is_registrant": True,
+                    "is_group": False,
+                    "name": self.full_name,
+                    "family_name": self.family_name,
+                    "given_name": self.given_name,
+                    "addl_name": self.addl_name,
+                    "birth_place": self.birth_place,
+                    "birthdate_not_exact": self.birthdate_not_exact,
+                    "birthdate": self.birthdate,
+                    "gender": self.gender,
+                    "phone_number_ids": phone_rec,
+                    "reg_ids": uid_rec,
+                }
+            )
         )
         individual_id.phone_number_ids_change()
         # Add to group

--- a/spp_change_request_add_farmer/models/change_request_add_farmer.py
+++ b/spp_change_request_add_farmer/models/change_request_add_farmer.py
@@ -284,29 +284,33 @@ class ChangeRequestAddChildren(models.Model):
             ]
         else:
             uid_rec = None
-        individual_id = self.env["res.partner"].create(
-            {
-                "is_registrant": True,
-                "is_group": False,
-                "name": self.full_name,
-                "family_name": self.family_name,
-                "given_name": self.given_name,
-                "addl_name": self.addl_name,
-                "birth_place": self.birth_place,
-                "birthdate_not_exact": self.birthdate_not_exact,
-                "birthdate": self.birthdate,
-                "gender": self.gender,
-                "image_1920": self.image_1920,
-                "experience_years": self.experience_years,
-                "formal_agricultural_training": self.formal_agricultural_training,
-                "farmer_national_id": self.farmer_national_id,
-                "farmer_household_size": self.farmer_household_size,
-                "farmer_postal_address": self.farmer_postal_address,
-                "marital_status": self.marital_status,
-                "highest_education_level": self.highest_education_level,
-                "phone_number_ids": phone_rec,
-                "reg_ids": uid_rec,
-            }
+        individual_id = (
+            self.env["res.partner"]
+            .sudo()
+            .create(
+                {
+                    "is_registrant": True,
+                    "is_group": False,
+                    "name": self.full_name,
+                    "family_name": self.family_name,
+                    "given_name": self.given_name,
+                    "addl_name": self.addl_name,
+                    "birth_place": self.birth_place,
+                    "birthdate_not_exact": self.birthdate_not_exact,
+                    "birthdate": self.birthdate,
+                    "gender": self.gender,
+                    "image_1920": self.image_1920,
+                    "experience_years": self.experience_years,
+                    "formal_agricultural_training": self.formal_agricultural_training,
+                    "farmer_national_id": self.farmer_national_id,
+                    "farmer_household_size": self.farmer_household_size,
+                    "farmer_postal_address": self.farmer_postal_address,
+                    "marital_status": self.marital_status,
+                    "highest_education_level": self.highest_education_level,
+                    "phone_number_ids": phone_rec,
+                    "reg_ids": uid_rec,
+                }
+            )
         )
         individual_id.phone_number_ids_change()
         # Add to group

--- a/spp_change_request_change_info/models/change_request_change_info.py
+++ b/spp_change_request_change_info/models/change_request_change_info.py
@@ -207,6 +207,10 @@ class ChangeRequestAddChildren(models.Model):
         return "default_change_request_change_info_id"
 
     def validate_data(self):
+        if not self.given_name:
+            raise ValidationError("Given Name is required!")
+        if not self.family_name:
+            raise ValidationError("Family Name is required!")
         super().validate_data()
         return
 
@@ -260,7 +264,7 @@ class ChangeRequestAddChildren(models.Model):
         if nid_rec:
             vals.update({"reg_ids": nid_rec})
         # Updating Registrant
-        self.registrant_id.write(vals)
+        self.registrant_id.sudo().write(vals)
 
     def open_registrant_details_form(self):
         self.ensure_one()


### PR DESCRIPTION
## Why is this change needed?

To fix the applying error on different CR Types (Add Child and Change Info)

## How was the change implemented?

Added sudo() in write or create function to the update_live_data function of the CR Types.

## New unit tests...

```
None
```

## Unit tests executed by the author...

```
None
```

## How to test manually...
- Install the CR Type module
- Create CR and go through the validation stages.
- Check if applied.

## Links
- https://github.com/orgs/OpenSPP/projects/5/views/4?pane=issue&itemId=50221529

## NOTES
sudo() were added to prevent the access rights issue in the applying stage of the CR. This is only added because we can't add the access rights of the said models on the error as the CR doesn't particularly connected to the said models. This happens because add child or change info and add farmer CR conflicts with each other.

