### PR TITLE
fix open form button on demo that conflicts with spp_registry_hierarchy

### DIFF
--- a/spp_farmer_registry_demo/models/farm.py
+++ b/spp_farmer_registry_demo/models/farm.py
@@ -1,7 +1,32 @@
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 
 class Farm(models.Model):
     _inherit = "res.partner"
 
     household_size = fields.Integer()
+
+
+class FarmGroupMembership(models.Model):
+    _inherit = "g2p.group.membership"
+
+    def open_member_form(self):
+        for rec in self:
+            if rec.individual:
+                if rec.individual.is_group:
+                    return {
+                        "name": "Group Membership",
+                        "view_mode": "form",
+                        "res_model": "res.partner",
+                        "res_id": rec.individual.id,
+                        "view_id": self.env.ref("g2p_registry_group.view_groups_form").id,
+                        "type": "ir.actions.act_window",
+                        "target": "new",
+                        "context": {"default_is_group": True},
+                        "flags": {"mode": "readonly"},
+                    }
+                else:
+                    return rec.open_individual_form()
+            else:
+                raise UserError(_("A group or individual must be specified for this member."))

--- a/spp_farmer_registry_demo/views/group_view.xml
+++ b/spp_farmer_registry_demo/views/group_view.xml
@@ -27,12 +27,12 @@
                         <field name="group_membership_ids" readonly="disabled" nolabel="1" colspan="4">
                             <tree default_order='status asc,ended_date asc'>
                                 <button
-                                    name="open_individual_form"
+                                    name="open_member_form"
                                     type="object"
                                     icon="fa-external-link"
-                                    title="Open Individual Form"
+                                    title="Open Form"
                                     class="btn-success"
-                                    string="Open Individual Form"
+                                    help="Open Member Form"
                                 />
                                 <field
                                     name="individual"

--- a/spp_registry_group_hierarchy/models/group_membership.py
+++ b/spp_registry_group_hierarchy/models/group_membership.py
@@ -51,4 +51,4 @@ class SPPGroupMembership(models.Model):
                 else:
                     return rec.open_individual_form()
             else:
-                raise UserError(_("A group or individual must be speficied for this member."))
+                raise UserError(_("A group or individual must be specified for this member."))


### PR DESCRIPTION
## Why is this change needed?

To fix the conflict of spp_farmer_registry_demo open membership form with spp_registry_hierarchy.

## How was the change implemented?

Added the same function from spp_registry_hierarchy on opening member form to be more dynamic. And modified the xml to use the function instead of open_individual_form.

## New unit tests...

```
None
```

## Unit tests executed by the author...

```
None
```

## How to test manually...
- Install the module `spp_farmer_registry_demo` alongside `spp_registry_hierarchy`
- Navigate to Group.
- Create a Group with a Group Kind that accepts both group or individual.
- Add Group and Individual as member of the created group.
- Click the open button in the Groups Member's Tab.
- Check if the correct form is being opened.

## Links
- https://github.com/orgs/OpenSPP/projects/5/views/4?pane=issue&itemId=53939084

## NOTES
- The function `open_member_form` from `spp_registry_hierarchy` were copied to `spp_farmer_registry_demo` to avoid the overriding of the button when `spp_registry_hierarchy` are installed alongside `spp_farmer_registry_demo`. I used this approach because the member's tab were redefined in `spp_farmer_registry_demo` and `spp_registry_hierarchy` can't depend on the demo module.

