### PR TITLE
Fix issue with group UI header texts

### DIFF
--- a/spp_registry_group_hierarchy/views/group_membership_views.xml
+++ b/spp_registry_group_hierarchy/views/group_membership_views.xml
@@ -14,6 +14,9 @@
                     Parent:
                 </attribute>
             </xpath>
+            <xpath expr="//field[@name='group']" position="attributes">
+                <attribute name="readonly">1</attribute>
+            </xpath>
             <xpath expr="//label[@for='individual']" position="attributes">
                 <attribute name="string">
                     Child:
@@ -25,6 +28,12 @@
             <xpath expr="//field[@name='individual']" position="attributes">
                 <attribute name="domain">
                     individual_domain
+                </attribute>
+                <attribute name="placeholder">
+                    Select Member...
+                </attribute>
+                <attribute name="string">
+                    Member
                 </attribute>
             </xpath>
         </field>

--- a/spp_registry_group_hierarchy/views/group_views.xml
+++ b/spp_registry_group_hierarchy/views/group_views.xml
@@ -57,6 +57,7 @@
                                     name="individual"
                                     options="{'no_open':True,'no_create_edit':True,'no_create':True}"
                                     domain="individual_domain"
+                                    string="Member"
                                 />
                             </h1>
                             <div class="o_row">


### PR DESCRIPTION
## Why is this change needed?

The UI header texts of group membership must be set to a generic term "Member" to be consistent with the combination of groups and individuals that the group type supports.

## How was the change implemented?

- Customize the **g2p_registry_membership.view_group_membership_form** and **g2p_registry_membership.view_groups_form_membership** form views to display the proper header text.

## New test case

```
```

## How to test manually...

1. Open an existing or create a new group.
2. Go to the "Members" tab.
3. Click "Add a line".
4. In the "Child" field, click "Search More".
5. The popup window must display "Search: Member" in its header.

## Links
- [Enhancement of Group Management: Hierarchical Structure and Type-Specific Properties](https://github.com/OpenSPP/openspp-modules/issues/339)