### PR TITLE
Fixed placeholder

### DIFF
--- a/spp_registry_group_hierarchy/views/group_membership_views.xml
+++ b/spp_registry_group_hierarchy/views/group_membership_views.xml
@@ -29,9 +29,7 @@
                 <attribute name="domain">
                     individual_domain
                 </attribute>
-                <attribute name="placeholder">
-                    Select Member...
-                </attribute>
+                <attribute name="placeholder">Select Member...</attribute>
                 <attribute name="string">
                     Member
                 </attribute>


### PR DESCRIPTION
## Why is this change needed?

Placeholder when trying to add a member in group registry is not aligned correctly.

## How was the change implemented?

- correctly alligned placeholder

## How to test manually...

- install `SPP Registry Group Hierarchy` module.
- Go to Registry -> Group.
- Open a group record
- Go to members tab and click `add a line`
- Check if the placeholder is now correctly aligned

## Links
- https://github.com/OpenSPP/openspp-modules/issues/339