### PR TITLE
fix overwrite match functionality

### DIFF
--- a/spp_import_match/models/import_match.py
+++ b/spp_import_match/models/import_match.py
@@ -66,6 +66,7 @@ class SPPImportMatch(models.Model):
                         domain.append((field_value, "=", row_value))
             if not combination_valid:
                 continue
+            _logger.info("DOMAIN: %s" % domain)
             match = model.search(domain)
             if len(match) == 1:
                 return match
@@ -85,6 +86,8 @@ class SPPImportMatch(models.Model):
             for f in record.field_ids:
                 if f.name in fields or f.field_id.name in fields:
                     result |= record
+        _logger.info("FIELD TO MATCH: %s" % field_to_match)
+        _logger.info("RESULT: %s" % result.ids)
         return result.ids, field_to_match
 
 


### PR DESCRIPTION
## Why is this change needed?

To fix the checking of overwrite match in the import match configuration.

## How was the change implemented?

Added the function to check if the overwrite match is either false or true and follow what is needed based on that value.

## New unit tests...

```
None
```

## Unit tests executed by the author...

```
None
```

## How to test manually...
- Install or upgrade the module `spp_import_match`
- Navigate to Registry > Configuration > Import Match.
- Create or update an Import Match configuration for res_partner (Contact).
- Check overwrite match check box if you want to overwrite a match or not if you want to skip the matched import.
- Check if the import is successful based on your configured import match.

## Links
- https://github.com/orgs/OpenSPP/projects/5/views/4?pane=issue&itemId=63081181
