### PR TITLE
fix buttons on program membership view

### DIFF
--- a/spp_manual_eligibility/__manifest__.py
+++ b/spp_manual_eligibility/__manifest__.py
@@ -17,6 +17,7 @@
     ],
     "data": [
         "views/program_view.xml",
+        "views/program_membership_view.xml",
         "wizard/create_program_wizard.xml",
     ],
     "assets": {},

--- a/spp_manual_eligibility/models/__init__.py
+++ b/spp_manual_eligibility/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import eligibility_manager
 from . import program
+from . import program_membership

--- a/spp_manual_eligibility/models/program_membership.py
+++ b/spp_manual_eligibility/models/program_membership.py
@@ -1,0 +1,23 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+import logging
+
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class G2PProgramMembership(models.Model):
+    _inherit = "g2p.program_membership"
+
+    is_manual_eligibility = fields.Boolean(compute="_compute_is_manual_eligibility")
+
+    def _compute_is_manual_eligibility(self):
+        for rec in self:
+            is_manual_eligibility = False
+            curr_eligibility_manager = self.env["g2p.program_membership.manager.default"].search(
+                [("program_id", "=", rec.program_id.id), ("is_manual_eligibility", "=", True)]
+            )
+            if curr_eligibility_manager:
+                is_manual_eligibility = True
+
+            rec.is_manual_eligibility = is_manual_eligibility

--- a/spp_manual_eligibility/tests/__init__.py
+++ b/spp_manual_eligibility/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_manual_eligibility

--- a/spp_manual_eligibility/tests/test_manual_eligibility.py
+++ b/spp_manual_eligibility/tests/test_manual_eligibility.py
@@ -1,0 +1,54 @@
+from odoo import fields
+from odoo.tests import TransactionCase
+
+
+class TestManualEligibility(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.registrant_1 = cls.env["res.partner"].create(
+            {
+                "name": "Registrant 1 [MANUAL ELIGIBILITY TEST]",
+                "is_registrant": True,
+                "is_group": True,
+            }
+        )
+        cls.registrant_1 = cls.env["res.partner"].create(
+            {
+                "name": "Registrant 2 [MANUAL ELIGIBILITY TEST]",
+                "is_registrant": True,
+                "is_group": True,
+            }
+        )
+        cls.program = cls.env["g2p.program"].create({"name": "Program 1 [MANUAL ELIGIBILITY TEST]"})
+        cls.manual_eligibility_manager = cls.env["g2p.program_membership.manager.default"].create(
+            {
+                "name": "Entitlement Manager Cash 1 [MANUAL ELIGIBILITY TEST]",
+                "is_manual_eligibility": True,
+                "eligibility_domain": None,
+                "program_id": cls.program.id,
+            }
+        )
+
+    def test_01_check_if_manual_eligibility(self):
+        self.program._compute_is_manual_eligibility()
+        self.assertEqual(self.program.is_manual_eligibility, True, "Correct value")
+        self.assertEqual(len(self.program.program_membership_ids), 0, "Start without members")
+        vals = [
+            {
+                "partner_id": self.registrant_1.id,
+                "program_id": self.program.id,
+                "state": "enrolled",
+                "enrollment_date": fields.Datetime.now(),
+            },
+            {
+                "partner_id": self.registrant_2.id,
+                "program_id": self.program.id,
+                "state": "enrolled",
+                "enrollment_date": fields.Datetime.now(),
+            },
+        ]
+        self.env["g2p.program_membership"].create(vals)
+        self.assertEqual(len(self.program.program_membership_ids), 2, "Finish with members")
+        self.program.program_membership_ids[0]._compute_is_manual_eligibility()
+        self.assertEqual(self.program.program_membership_ids[0].is_manual_eligibility, True, "Correct value")

--- a/spp_manual_eligibility/tests/test_manual_eligibility.py
+++ b/spp_manual_eligibility/tests/test_manual_eligibility.py
@@ -13,7 +13,7 @@ class TestManualEligibility(TransactionCase):
                 "is_group": True,
             }
         )
-        cls.registrant_1 = cls.env["res.partner"].create(
+        cls.registrant_2 = cls.env["res.partner"].create(
             {
                 "name": "Registrant 2 [MANUAL ELIGIBILITY TEST]",
                 "is_registrant": True,

--- a/spp_manual_eligibility/views/program_membership_view.xml
+++ b/spp_manual_eligibility/views/program_membership_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+-->
+<odoo>
+    <record id="view_program_membership_manual_eligibility_form" model="ir.ui.view">
+        <field name="name">view_program_membership_manual_eligibility_form</field>
+        <field name="model">g2p.program_membership</field>
+        <field name="priority">1010</field>
+        <field name="inherit_id" ref="g2p_programs.view_program_membership_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='is_group']" position="after">
+                <field name="is_manual_eligibility" invisible="1" />
+            </xpath>
+            <xpath expr="//button[@name='verify_eligibility']" position="attributes">
+                <attribute name="invisible">
+                    is_manual_eligibility or state not in ('draft','enrolled')
+                </attribute>
+            </xpath>
+            <xpath expr="//button[@name='enroll_eligible_registrants']" position="attributes">
+                <attribute name="invisible">
+                    is_manual_eligibility or state != 'draft'
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Why is this change needed?

To fix the buttons of enroll and verify in program membership view.

## How was the change implemented?

Added a compute field to check if the program's eligibility manager is manual then hide the enroll and verify button in program membership view.

## New unit tests...

```
None
```

## Unit tests executed by the author...

```
None
```

## How to test manually...
- Install or upgrade the module `spp_manual_eligibility`
- Navigate to Program.
- Create a Program with Manual Eligibility as its Eligibility Manager.
- Manually add beneficiaries.
- Go to the Program.
- Go to the Beneficiaries > Open one Beneficiary and check if the button enroll or verify is hidden.
- Go to Registry > Group if the program target type is Group else Individual > Open one member and go to Programs Tab
- Open the Program with the Manual Eligibility and check if the pop-up form doesn't have the enroll or verify button.

## Links
- https://github.com/orgs/OpenSPP/projects/5/views/4?pane=issue&itemId=72013285

