### PR TITLE
fix test error on change info change request

### DIFF
--- a/spp_change_request_change_info/tests/test_create_cr.py
+++ b/spp_change_request_change_info/tests/test_create_cr.py
@@ -54,7 +54,12 @@ class ChangeRequestChangeInfoTest(TransactionCase):
             self.res_id.action_submit()
 
     def test_02_validate_cr_with_complete_data(self):
-        self.res_id.write({"family_name": "Test"})
+        self.res_id.write(
+            {
+                "family_name": "Test",
+                "given_name": "Test",
+            }
+        )
         file = None
         filename = None
         file_path = f"{os.path.dirname(os.path.abspath(__file__))}/sample_document.jpeg"


### PR DESCRIPTION
## Why is this change needed?

To fix the error in tests.

## How was the change implemented?

Modified the test_create_cr.

## New unit tests...

```
None
```

## Unit tests executed by the author...

```
spp_change_request_change_info/tests/test_create_cr.py::ChangeRequestChangeInfoTest
```


