### PR TITLE
Added category for OpenSPP

### DIFF
--- a/spp_base/__manifest__.py
+++ b/spp_base/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "OpenSPP Base",
-    "category": "OpenSPP",
+    "category": "OpenSPP/OpenSPP",
     "version": "17.0.1.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",


### PR DESCRIPTION
## **Why is this change needed?**

in Apps Menu, currently there is no category that is dedicated for OpenSPP

## **How was the change implemented?**

Upon checking, there is already an existing category for OpenSPP but the problem it is hidden, i just created a children for that category so that it will not be hidden anymore

## **New unit tests**

No Unit test

## **Unit tests executed by the author**

No Unit test

## **How to test manually**

- Go to Apps Menu.
- Click the `Update Apps List` button in the top left corner of the page then click Update button.
- In the Category Section, check if there is a new category named `OpenSPP`
- click the category `OpenSPP`
- CHeck if the list of apps has been filtered to only the apps that is created by OpenSPP team.

## **Related links**

https://github.com/OpenSPP/openspp-modules/issues/513