### PR TITLE
Area import improvements

### DIFF
--- a/spp_area/models/area_import.py
+++ b/spp_area/models/area_import.py
@@ -386,6 +386,14 @@ class OpenSPPAreaImportActivities(models.Model):
         (POSTED, POSTED),
     ]
 
+    STATE_ORDER = {
+        ERROR: 0,
+        NEW: 1,
+        VALIDATED: 2,
+        UPDATED: 3,
+        POSTED: 4,
+    }
+
     area_import_id = fields.Many2one("spp.area.import", "Area Import", required=True)
     admin_name = fields.Char(translate=True)
     admin_code = fields.Char()
@@ -403,6 +411,15 @@ class OpenSPPAreaImportActivities(models.Model):
         "Status",
         default="New",
     )
+    state_order = fields.Integer(
+        compute="_compute_state_order",
+        store=True,
+    )
+
+    @api.depends("state")
+    def _compute_state_order(self):
+        for rec in self:
+            rec.state_order = self.STATE_ORDER[rec.state]
 
     def check_errors(self):
         self.ensure_one()

--- a/spp_area/views/area_import_views.xml
+++ b/spp_area/views/area_import_views.xml
@@ -118,6 +118,7 @@
                             decoration-it="state=='Error'"
                             decoration-danger="state=='Error'"
                             decoration-success="state=='Posted'"
+                            default_order="state_order"
                         >
                             <field
                                 name="state"
@@ -134,6 +135,7 @@
                             <field name="parent_name" />
                             <field name="parent_code" />
                             <field name="level" />
+                            <field name="state_order" column_invisible="1" />
                         </tree>
                         <form string="Raw Data" duplicate="0" create="0">
                             <header>

--- a/spp_area_gis/models/area_import.py
+++ b/spp_area_gis/models/area_import.py
@@ -37,6 +37,10 @@ class OpenSPPAreaImportActivities(models.Model):
             errors.append(_("Latitude must be between -90 and 90"))
         if self.longitude and (self.longitude < -180 or self.longitude > 180):
             errors.append(_("Longitude must be between -180 and 180"))
+        if self.latitude and not self.longitude:
+            errors.append(_("Longitude is required if Latitude is provided"))
+        if self.longitude and not self.latitude:
+            errors.append(_("Latitude is required if Longitude is provided"))
         return errors
 
     def get_area_vals(self):

--- a/spp_area_gis/tests/test_area_import_raw.py
+++ b/spp_area_gis/tests/test_area_import_raw.py
@@ -18,6 +18,18 @@ class AreaImportRawTest(AreaImportRawTestMixin):
         self.assertIn("Latitude must be between -90 and 90", self.area_import_raw_id.remarks)
         self.assertIn("Longitude must be between -180 and 180", self.area_import_raw_id.remarks)
 
+        self.area_import_raw_id.latitude = False
+        self.area_import_raw_id.longitude = 179
+        self.area_import_raw_id.validate_raw_data()
+        self.assertEqual(self.area_import_raw_id.state, "Error")
+        self.assertIn("Latitude is required if Longitude is provided", self.area_import_raw_id.remarks)
+
+        self.area_import_raw_id.latitude = 89
+        self.area_import_raw_id.longitude = False
+        self.area_import_raw_id.validate_raw_data()
+        self.assertEqual(self.area_import_raw_id.state, "Error")
+        self.assertIn("Longitude is required if Latitude is provided", self.area_import_raw_id.remarks)
+
     def test_get_area_vals(self):
         area_vals = self.area_import_raw_id.get_area_vals()
 


### PR DESCRIPTION
## **Why is this change needed?**

- Currently when importing an area, the error will not show immediately unless the table is manually sorted
- There is no validation when a coordinates is missing a latitude or longitude

## **How was the change implemented?**

- Automatically sort the table where the errors are first to show.
- Added two new validations for latitude and longitude.

## **New unit tests**

- spp_area_gis/tests/test_area_import_raw.py::AreaImportRawTest::test_check_errors

## **Unit tests executed by the author**

- spp_area/tests/test_area_import.py::AreaImportTest
- spp_area/tests/test_area_import_raw.py::AreaImportRawTest
- spp_area_gis/tests/test_area_import.py::AreaImportTest
- spp_area_gis/tests/test_area_import_raw.py::AreaImportRawTest

## **How to test manually**

- go to Area
- Click "Areas" beside Area and it should display "Area import" in one of the list items.
- Click Area import then upload the file attached in this ticket then click import
- Click Validate data
- Check if the table are now sorted where the errors should be in the first rows
- Check if the new validations for latitude and longitude is showing if atleast one of the coordinates is missing.

## **Related links**

https://github.com/OpenSPP/openspp-modules/issues/514
