### PR TITLE
add validation error upon importing

### DIFF
--- a/spp_farmer_registry_base/__manifest__.py
+++ b/spp_farmer_registry_base/__manifest__.py
@@ -20,6 +20,7 @@
         "g2p_registry_membership",
         "spp_base_gis",
         "spp_land_record",
+        "base_import",
     ],
     "external_dependencies": {"python": ["shapely", "geojson", "simplejson", "pyproj"]},
     "data": [

--- a/spp_farmer_registry_base/models/__init__.py
+++ b/spp_farmer_registry_base/models/__init__.py
@@ -11,3 +11,4 @@ from . import farmer
 from . import species
 from . import farm
 from . import land_record
+from . import base_import

--- a/spp_farmer_registry_base/models/base_import.py
+++ b/spp_farmer_registry_base/models/base_import.py
@@ -1,0 +1,16 @@
+import logging
+
+from odoo import _, models
+from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class SPPBaseImport(models.TransientModel):
+    _inherit = "base_import.import"
+
+    def execute_import(self, fields, columns, options, dryrun=False):
+        if self.res_model == "res.partner":
+            if "is_group" in fields and not ("farmer_given_name" in fields and "farmer_family_name" in fields):
+                raise ValidationError(_("Farmer Given Name or Farmer Family Name is required"))
+        return super().execute_import(fields, columns, options, dryrun=dryrun)


### PR DESCRIPTION
## **Why is this change needed?**
To raise Error if the group being imported doesn't have farmer family name or given name

## **How was the change implemented?**
Added a checking on base import if the model is res partner and in group but doesn't have farmer names in the excel or csv

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
- Install or Upgrade `spp_farmer_registry_base`.
- Go to Groups/ Farmer Group/ Farm.
- Try Importing without the farmer names (family name and given name) but make sure `is_group` is in the excel file.
- Test if it raise error.

## **Related links**
https://github.com/orgs/OpenSPP/projects/5/views/4?pane=issue&itemId=74597423

