### PR TITLE
Improved validation of the farmer member

### DIFF
--- a/spp_farmer_registry_base/tests/__init__.py
+++ b/spp_farmer_registry_base/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_farm

--- a/spp_farmer_registry_base/tests/test_farm.py
+++ b/spp_farmer_registry_base/tests/test_farm.py
@@ -1,0 +1,79 @@
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class MembershipTest(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.registrant_1 = cls.env["res.partner"].create(
+            {
+                "family_name": "Franco",
+                "given_name": "Chin",
+                "name": "Chin Franco",
+                "is_group": False,
+                "is_registrant": True,
+            }
+        )
+        cls.farm_1 = cls.env["res.partner"].create(
+            {
+                "name": "Farm 1",
+                "is_group": True,
+                "is_registrant": True,
+                "farmer_family_name": "Butay",
+                "farmer_given_name": "Red",
+            }
+        )
+        # cls.group_membership_1 = cls.env["g2p.group.membership"].create(
+        #     {
+        #         "group": cls.group_1.id,
+        #         "individual": cls.registrant_1.id,
+        #         "kind": [(6, 0, cls.env.ref("g2p_registry_membership.group_membership_kind_head").ids)],
+        #     }
+        # )
+
+    def test_get_group_head_member(self):
+        head_id = self.farm_1.get_group_head_member()
+        self.assertTrue(head_id)
+
+        ind_head_id = self.registrant_1.get_group_head_member()
+        self.assertFalse(ind_head_id)
+
+    def test_write(self):
+        with self.assertRaisesRegex(ValidationError, "Farm must have a head member."):
+            self.farm_1.write({"group_membership_ids": [(2, self.farm_1.group_membership_ids.id)]})
+
+    def test_write_change_head(self):
+        def get_head_member(farm):
+            for member in self.farm_1.group_membership_ids:
+                if head_kind_id in member.kind:
+                    return member
+
+        head_kind_id = self.env.ref("g2p_registry_membership.group_membership_kind_head")
+
+        head_member = get_head_member(self.farm_1)
+
+        self.group_membership_1 = self.env["g2p.group.membership"].create(
+            {
+                "group": self.farm_1.id,
+                "individual": self.registrant_1.id,
+                "kind": [(6, 0, self.env.ref("g2p_registry_membership.group_membership_kind_head").ids)],
+            }
+        )
+        self.farm_1.write({"group_membership_ids": [(2, head_member.id)]})
+
+        self.assertEqual(self.farm_1.farmer_family_name, self.registrant_1.family_name)
+        self.assertEqual(self.farm_1.farmer_given_name, self.registrant_1.given_name)
+
+    def test_head_info(self):
+        head_member_id = self.farm_1.get_group_head_member()
+        head_member_id.write(
+            {
+                "family_name": "Test Family Name",
+                "given_name": "Test Given Name",
+            }
+        )
+
+        self.assertEqual(self.farm_1.farmer_family_name, "Test Family Name")
+        self.assertEqual(self.farm_1.farmer_given_name, "Test Given Name")


### PR DESCRIPTION
## **Why is this change needed?**

To improve the validation of modifying the members of a farm

## **How was the change implemented?**

Added validations on the modification of the member

## **New unit tests**

spp_farmer_registry_base/tests/__init__.py::MembershipTest

## **Unit tests executed by the author**

spp_farmer_registry_base/tests/__init__.py::MembershipTest

## **How to test manually**

- Install spp_farmer_registry_base module
- Create or Generate a farm
- If there's no head member, add a head member then save
- Try to delete the head member then save again.
- Check if there will be an error.
- Change head member.
- Check if the information in the Farmer tab is also changed.

## **Related links**
https://github.com/OpenSPP/openspp-acf/issues/38
