### PR TITLE
Remove instance of 'PDS' in certain modules

### DIFF
--- a/spp_audit_config/data/audit_rule_data.xml
+++ b/spp_audit_config/data/audit_rule_data.xml
@@ -20,7 +20,7 @@
         <value name="model">res.partner</value>
         <value
             name="fields_to_log"
-            eval="['name', 'registration_date', 'active_group', 'address', 'age', 'area_center_id', 'area_id', 'birth_place', 'birthdate', 'email', 'gender', 'grp_member_names', 'grp_member_uid', 'individual_status', 'lang', 'molsa_vulnerability_level', 'mother_name', 'pds_number', 'phone', 'phone_number_ids', 'relation_to_head', 'service_point_ids', 'unified_id']"
+            eval="['name', 'registration_date', 'active_group', 'address', 'age', 'area_center_id', 'area_id', 'birth_place', 'birthdate', 'email', 'gender', 'grp_member_names', 'grp_member_uid', 'individual_status', 'lang', 'molsa_vulnerability_level', 'mother_name', 'phone', 'phone_number_ids', 'relation_to_head', 'service_point_ids', 'unified_id']"
         />
     </function>
 

--- a/spp_change_request/data/dms.xml
+++ b/spp_change_request/data/dms.xml
@@ -21,7 +21,7 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
         <field name="name">UID Card</field>
     </record>
 
-    <record id="pds_dms_extra_documents" model="spp.dms.category">
+    <record id="spp_dms_extra_documents" model="spp.dms.category">
         <field name="name">Extra Documents</field>
     </record>
 

--- a/spp_change_request/i18n/ar.po
+++ b/spp_change_request/i18n/ar.po
@@ -620,11 +620,6 @@ msgstr ""
 "خطأ في مراحل التحقق من الصحة. لا توجد مرحلة متاحة لتعيين هذا التحقق من الصحة."
 
 #. module: spp_change_request
-#: model:dms.category,name:spp_change_request.pds_dms_extra_documents
-msgid "Extra Documents"
-msgstr "مستندات اضافية"
-
-#. module: spp_change_request
 #: model:ir.model,name:spp_change_request.model_dms_file
 msgid "File"
 msgstr "ملف"

--- a/spp_change_request/i18n/ckb.po
+++ b/spp_change_request/i18n/ckb.po
@@ -603,11 +603,6 @@ msgid ""
 msgstr ""
 
 #. module: spp_change_request
-#: model:dms.category,name:spp_change_request.pds_dms_extra_documents
-msgid "Extra Documents"
-msgstr ""
-
-#. module: spp_change_request
 #: model:ir.model,name:spp_change_request.model_dms_file
 msgid "File"
 msgstr ""

--- a/spp_change_request/i18n/fr.po
+++ b/spp_change_request/i18n/fr.po
@@ -636,12 +636,6 @@ msgstr ""
 "cette validation."
 
 #. module: spp_change_request
-#: model:dms.category,name:spp_change_request.pds_dms_extra_documents
-#, fuzzy
-msgid "Extra Documents"
-msgstr "Documents supplémentaires"
-
-#. module: spp_change_request
 #: model:ir.model,name:spp_change_request.model_dms_file
 #, fuzzy
 msgid "File"

--- a/spp_change_request/models/mixins/source_mixin.py
+++ b/spp_change_request/models/mixins/source_mixin.py
@@ -552,7 +552,6 @@ class ChangeRequestSourceMixin(models.AbstractModel):
             self.copy_group_member_ids("group_member_id")
             self.copy_group_member_ids("group_member_id", group_ref_field="registrant_id")
             self.copy_group_member_ids("group_member_id", model_name="spp.change.request")
-            self.copy_group_member_ids("group_member_id", model_name=["spp.change.request", "pds.change.request"])
 
             def my_condition(self):
                 if self.state == 'draft':
@@ -584,7 +583,7 @@ class ChangeRequestSourceMixin(models.AbstractModel):
                     change_request_field: rec.id,
                     "service_point_id": mrec.id,
                 }
-                self.env["pds.change.request.service.point"].create(service_points)
+                self.env["spp.change.request.service.point"].create(service_points)
 
     def _copy_from_group_member_ids(self, group_ref_field, group_id_field, skip_head=True):
         for rec in self:
@@ -603,7 +602,7 @@ class ChangeRequestSourceMixin(models.AbstractModel):
                         "kind_ids": kind_ids,
                         "new_relation_to_head": None,
                     }
-                    self.env["pds.change.request.src.grp"].create(group_members)
+                    self.env["spp.change.request.src.grp"].create(group_members)
 
     def open_applicant_details_form(self):
         """

--- a/spp_change_request/models/mixins/source_mixin.py
+++ b/spp_change_request/models/mixins/source_mixin.py
@@ -576,34 +576,6 @@ class ChangeRequestSourceMixin(models.AbstractModel):
                         for model in model_name:
                             self.env[model].create(group_members)
 
-    def _copy_service_point_ids(self, change_request_field):
-        for rec in self:
-            for mrec in rec.registrant_id.service_point_ids:
-                service_points = {
-                    change_request_field: rec.id,
-                    "service_point_id": mrec.id,
-                }
-                self.env["spp.change.request.service.point"].create(service_points)
-
-    def _copy_from_group_member_ids(self, group_ref_field, group_id_field, skip_head=True):
-        for rec in self:
-            for mrec in rec[group_ref_field].group_membership_ids:
-                kind_ids = mrec.kind and mrec.kind.ids or None
-                if (
-                    kind_ids
-                    and (
-                        not skip_head
-                        or self.env.ref("g2p_registry_membership.group_membership_kind_head").id not in kind_ids
-                    )
-                ) or not kind_ids:
-                    group_members = {
-                        group_id_field: rec.id,
-                        "individual_id": mrec.individual.id,
-                        "kind_ids": kind_ids,
-                        "new_relation_to_head": None,
-                    }
-                    self.env["spp.change.request.src.grp"].create(group_members)
-
     def open_applicant_details_form(self):
         """
         Get and opens the form view of the applicant_id to view details

--- a/spp_service_points/tests/test_service_point.py
+++ b/spp_service_points/tests/test_service_point.py
@@ -85,7 +85,7 @@ class TestServicePoint(TransactionCase):
     #     self.assertNotEqual(
     #         self.service_point_1.phone_sanitized,
     #         False,
-    #         "Service Point 1 having correct Iraq phone number format, should have phone sanitized!",
+    #         "Service Point 1 having correct phone number format, should have phone sanitized!",
     #     )
 
     def test_02_disable_active_service_point(self):


### PR DESCRIPTION
## **Why is this change needed?**

- Remove the instances of the term "PDS" abd "Iraq" in certain OpenSPP modules

## **How was the change implemented?**

- Update all modules with the term "PDS"
- Remove unused "PDS" terms
- Modify fields or models with the appropriate names

## **New unit tests**

- None

## **Unit tests executed by the author**

- None

## **How to test manually**

- For developers only. Search for the term pds in all modules

## **Related links**

