### PR TITLE
Entitlement approve validation improvements

### DIFF
--- a/spp_programs/models/entitlement_cash.py
+++ b/spp_programs/models/entitlement_cash.py
@@ -1,9 +1,19 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
+from odoo.exceptions import ValidationError
+
+from odoo.addons.g2p_programs.models.constants import STATE_APPROVED
 
 
 class CashEntitlement(models.Model):
     _inherit = "g2p.entitlement"
 
     id_number = fields.Char()
+
+    def approve_entitlement(self):
+        for rec in self:
+            if rec.cycle_id.state != STATE_APPROVED:
+                raise ValidationError("The cycle must be approved before approving entitlement")
+
+        return super().approve_entitlement()


### PR DESCRIPTION
## **Why is this change needed?**

It is possible to approve the entitlement even though the cycle is not yet approved

## **How was the change implemented?**

Added a validation in approving entitlements where it will not proceed in approving if the cycle is still not approved.

## **New unit tests**

spp_programs/tests/test_entitlement.py::TestEntitlement::test_12_approve_entitlement

## **Unit tests executed by the author**

spp_programs/tests/test_entitlement.py::TestEntitlement

## **How to test manually**

- Install spp_programs module
- Create a program
- Create a cycle under the program
- Enter the cycle
- Click `Prepare Entitlement` button.
- Enter Entitlement page using the Entitlement button in the top-center page.

- Either approve one or all of the entitlements.
- Check if an error shows

- Go back to Cycle and approve it
- Go back to Entitlements page and approve them
- Check if there is no error anymore

## **Related links**

https://github.com/OpenSPP/openspp-modules/issues/538

