### PR TITLE
Reverting urllib3 pinning because of conflicting requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,4 @@ simplejson
 swagger_spec_validator
 xlrd
 numpy>=1.22.2 # not directly required, pinned by Snyk to avoid a vulnerability
-urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
The modules odoo-addon-g2p-documents and odoo-addon-storage-backend-s3 require an earlier version