### PR TITLE
Fixed vci issuer

### DIFF
--- a/spp_openid_vci/models/res_partner.py
+++ b/spp_openid_vci/models/res_partner.py
@@ -116,5 +116,5 @@ class SPPRegistry(models.Model):
 
         self.vc_qr_code = qr_img
 
-        admission_form = self.env.ref("spp_openid_vci.action_generate_id_card").report_action(self)
+        admission_form = self.env.ref("spp_openid_vci.action_generate_id_card").report_action(self, config=False)
         return admission_form


### PR DESCRIPTION
## **Why is this change needed?**

Upon printing the vci issuer, the invoice is printed instead of vci issuer and this is happening on a random occasion

## **How was the change implemented?**

Now, I added an argument config=False so that it will always go to the vci issuer

## **How to test manually**

- Install module `spp_openid_vci_individual`
- Go to settings and click `Activate the developer mode`
- Go to Settings -> User & Companies -> Users.
- Enter the record Administrator.
- Go to Access Rights tab and check the `Crypto Admin` Role
- Refresh the page. You should now be able to see the `Encryption Providers` Menu on top of the page. Click that menu.
- Enter the `Default encryption provider` record.
- In `Type` field, select the `JWCrypto` then Click the button `Create Jwcrpyto Key` then Save.
- Go to VCI Issuer menu and create a record.
- Fillup only the following: Name, Scope, Issuer Type, Supported Format, Encryption Provider, and Auth Subject ID Type
- Upon saving, other fields will be automatically fill-up.
- Go to Registry -> Individuals and create or update a record.
- Make sure the the Individual have an ID type with the same ID Type selected in `Auth Subject ID Type`
- Click the `Issue Card` button in the top-middle of the page.
- Select the Issuer that was created earlier then click Confirm.
- There should be a downloaded pdf file for vci issuer.

## **Related links**

https://github.com/OpenSPP/openspp-modules/issues/372

