### PR TITLE
Use Ubuntu 22.04 (jammy) images for CI

### DIFF
--- a/.github/workflows/test-legacy.yml
+++ b/.github/workflows/test-legacy.yml
@@ -36,10 +36,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: ghcr.io/openspp/oca-ci/py3.10-odoo17.0:latest
-            name: test with Odoo
-#          - container: ghcr.io/openspp/oca-ci/py3.10-ocb17.0:latest
-#            name: test with OCB
+          - container: ghcr.io/openspp/oca-ci/py3.10-odoo17.0:jammy
+            name: test with Odoo 17/Ubuntu 22.04
             makepot: "true"
             sonar: "true"
     services:

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -39,10 +39,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: ghcr.io/openspp/oca-ci/py3.10-odoo17.0:latest
-            name: test with Odoo
-#          - container: ghcr.io/openspp/oca-ci/py3.10-ocb17.0:latest
-#            name: test with OCB
+          - container: ghcr.io/openspp/oca-ci/py3.10-odoo17.0:jammy
+            name: test with Odoo 17/Ubuntu 22.04
             makepot: "true"
             sonar: "true"
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: ghcr.io/openspp/oca-ci/py3.10-odoo17.0:latest
-            name: test with Odoo
-#          - container: ghcr.io/openspp/oca-ci/py3.10-ocb17.0:latest
-#            name: test with OCB
+          - container: ghcr.io/openspp/oca-ci/py3.10-odoo17.0:jammy
+            name: test with Odoo 17/Ubuntu 22.04
             makepot: "true"
             sonar: "true"
     services:


### PR DESCRIPTION
## **Why is this change needed?**
GH Actions (CI) should match production and documentation

## **How was the change implemented?**
Switching to an Ubuntu 22.04 image
