### PR TITLE
Updating requirements to pin libs

### DIFF
--- a/openg2p-requirements.txt
+++ b/openg2p-requirements.txt
@@ -6,8 +6,6 @@ odoo-addon-g2p-registry-individual==17.0.1.0.0.25
 odoo-addon-g2p-registry-membership==17.0.1.0.0.15
 odoo-addon-g2p-programs==17.0.1.0.0.70
 odoo-addon-g2p-entitlement-in-kind==17.0.1.0.0.4
-odoo-addon-g2p-payment-cash==17.0.1.0.0.9
-odoo-addon-g2p-payment-g2p-connect==17.0.1.0.0.10
 odoo-addon-g2p-payment-interop-layer==17.0.1.0.0.8
 odoo-addon-g2p-payment-phee==17.0.1.0.0.6
 odoo-addon-g2p-program-approval==17.0.1.0.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
 # generated from manifests external_dependencies
-Pillow>=10.3.0
+Pillow>=9.3.0
 PyLD
 bravado_core
 faker
 geojson
 jsonschema
 jwcrypto
+numpy>=1.22.2
 pyjwt>=2.4.0
 pyproj
 python-magic
@@ -13,6 +14,6 @@ qrcode
 shapely
 simplejson
 swagger_spec_validator
+urllib3>=2.2.2
 xlrd
-numpy>=1.22.2 # not directly required, pinned by Snyk to avoid a vulnerability
-zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+zipp>=3.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # generated from manifests external_dependencies
-Pillow>=9.3.0
+Pillow>=10.3.0
 PyLD
 bravado_core
 faker

--- a/spp_base/__manifest__.py
+++ b/spp_base/__manifest__.py
@@ -27,7 +27,9 @@
         "spp_custom_fields_ui",
         "spp_programs",
     ],
-    "external_dependencies": {},
+    "external_dependencies": {
+        "python": ["numpy>=1.22.2", "urllib3>=2.2.2", "zipp>=3.19.1"]
+    },  # not directly required, pinned by Snyk to avoid a vulnerability
     "data": [
         "security/ir.model.access.csv",
         "data/top_up_card.xml",

--- a/spp_dms/__manifest__.py
+++ b/spp_dms/__manifest__.py
@@ -13,7 +13,7 @@
     "depends": [
         "base",
     ],
-    "external_dependencies": {"python": ["Pillow>=9.3.0"]},
+    "external_dependencies": {"python": ["Pillow>=10.3.0"]},
     "data": [
         "security/security.xml",
         "security/ir.model.access.csv",


### PR DESCRIPTION
## **Why is this change needed?**
- To allow us to use a version of urllib3 without known vulnerabilities
- To allow pre-commit to pass without errors

## **How was the change implemented?**
- Removed dependencies from `openg2p-reqiurements`
- Added the pinned libraries to `spp_base`

