### PR TITLE
Remove pyjq dependencies from our GH Actions

### DIFF
--- a/.github/workflows/test-legacy.yml
+++ b/.github/workflows/test-legacy.yml
@@ -105,10 +105,6 @@ jobs:
         run: |
           cp spp-test-requirements.txt test-requirements.txt
           cat test-requirements.txt
-      - name: Installing specific Debian packages to be able to pip install pyjq
-        run: |
-          apt-get update
-          apt-get install -y autoconf automake libtool libtool-bin bison flex
       - name: Install addons and dependencies
         env:
           SKIP_EXT_DEB_DEPENDENCIES: "true"

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -70,10 +70,6 @@ jobs:
           echo "odoo-addon-muk-web-theme==17.0.1.2.1.3" >> tmp-requirements.txt
           cat test-requirements.txt >> tmp-requirements.txt
           cp tmp-requirements.txt test-requirements.txt
-      - name: Installing specific Debian packages to be able to pip install pyjq
-        run: |
-          apt-get update
-          apt-get install -y autoconf automake libtool libtool-bin bison flex
       - name: Install addons and dependencies
         env:
           SKIP_EXT_DEB_DEPENDENCIES: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,10 +136,6 @@ jobs:
           cat test-requirements.txt
           sed -i '/openspp-modules/! { /OpenG2P\/\(openg2p\)/! { s|OpenG2P/|OpenSPP/openg2p-|; s/@17.0\(-develop\)\?/@v17.0.1.2-openspp/; }; /OpenG2P/ { s/OpenG2P/OpenSPP/g; s/@17.0\(-develop\)\?/@v17.0.1.2-openspp/; } }' test-requirements.txt
           cat test-requirements.txt
-      - name: Installing specific Debian packages to be able to pip install pyjq
-        run: |
-          apt-get update
-          apt-get install -y autoconf automake libtool libtool-bin bison flex
       - name: Install addons and dependencies
         env:
           SKIP_EXT_DEB_DEPENDENCIES: "true"


### PR DESCRIPTION
## **Why is this change needed?**
Removing the temporarily added dependencies to reduce the runtime of our GH Actions.
These were added as openg2p-vci was using them. Now that openg2p-vci has moved to `jq`, we no longer need to install the dependencies required to install pyjq.

See https://github.com/OpenG2P/openg2p-vci/pull/11