### PR TITLE
Added other SPP modules to OpenSPP category

### DIFF
--- a/spp_api/__manifest__.py
+++ b/spp_api/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "OpenSPP API",
     "summary": "Provides a framework for building and managing a RESTful API for the OpenSPP platform, including API definition, documentation, security, and logging.",
-    "category": "",
+    "category": "OpenSPP",
     "images": [
         "images/icon.png",
     ],

--- a/spp_api_records/__manifest__.py
+++ b/spp_api_records/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP API Records",
     "summary": """Provides RESTful API endpoints for accessing and managing OpenSPP's core data, including service points, programs, products, and entitlements.""",
-    "category": "",
+    "category": "OpenSPP",
     "version": "17.0.1.0.0",
     "author": "OpenSPP.org",
     "development_status": "Alpha",

--- a/spp_base_api/__manifest__.py
+++ b/spp_base_api/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "OpenSPP Base API",
     "summary": """Provides foundational API functions and methods for seamless interaction with the OpenSPP system, enabling data exchange via APIs or XML-RPC.""",
-    "category": "Hidden",
+    "category": "OpenSPP",
     "version": "17.0.1.0.0",
     "application": False,
     "author": "OpenSPP.org",

--- a/spp_basic_cash_entitlement_spent/__manifest__.py
+++ b/spp_basic_cash_entitlement_spent/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
 {
     "name": "OpenSPP Program Entitlement Basic Cash Spent",
-    "category": "G2P",
+    "category": "OpenSPP",
     "version": "17.0.1.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",

--- a/spp_custom_field_custom_filter/__manifest__.py
+++ b/spp_custom_field_custom_filter/__manifest__.py
@@ -4,7 +4,7 @@
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",
     "license": "LGPL-3",
-    "category": "",
+    "category": "OpenSPP",
     "depends": [
         "spp_custom_fields_ui",
         "spp_custom_filter",

--- a/spp_dci_api_server/__manifest__.py
+++ b/spp_dci_api_server/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "OpenSPP DCI API Server",
     "summary": "Provides a DCI-compliant RESTful API for secure data exchange with OpenSPP's registry.",
-    "category": "",
+    "category": "OpenSPP",
     "version": "17.0.1.0.0",
     "author": "OpenSPP.org",
     "development_status": "Alpha",

--- a/spp_entitlement_cash/__manifest__.py
+++ b/spp_entitlement_cash/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Cash Entitlement",
     "summary": "Manage cash-based entitlements for beneficiaries within social protection programs, including defining calculation rules, automating disbursement, and tracking payments.",
-    "category": "SPP",
+    "category": "OpenSPP",
     "version": "17.0.1.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",

--- a/spp_import_dci_api/__manifest__.py
+++ b/spp_import_dci_api/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP Import: DCI API",
     "summary": "Enables integration with external registries, particularly those adhering to the DCI (Digital Civil Identity) standard, for importing and synchronizing registrant data into OpenSPP.",
-    "category": "",
+    "category": "OpenSPP",
     "version": "17.0.1.0.0",
     "author": "OpenSPP.org",
     "development_status": "Alpha",

--- a/spp_oauth/__manifest__.py
+++ b/spp_oauth/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP API: Oauth",
     "summary": "Provides OAuth 2.0 authentication for secure access to the OpenSPP API.",
-    "category": "",
+    "category": "OpenSPP",
     "version": "17.0.1.0.0",
     "author": "OpenSPP.org",
     "development_status": "Alpha",

--- a/spp_starter/__manifest__.py
+++ b/spp_starter/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "OpenSPP: Starter",
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",
-    "category": "Theme",
+    "category": "OpenSPP",
     "version": "17.0.1.0.0",
     "license": "LGPL-3",
     "development_status": "Beta",

--- a/theme_openspp_muk/__manifest__.py
+++ b/theme_openspp_muk/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "OpenSPP Theme (Muk Theme)",
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",
-    "category": "Theme",
+    "category": "OpenSPP",
     "version": "17.0.1.0.0",
     "depends": [
         "base",


### PR DESCRIPTION
## **Why is this change needed?**

Some OpenSPP modules is not included in the OpenSPP Category

## **How was the change implemented?**

Added OpenSPP category in the manifest.py file

## **New unit tests**

No Unit Test

## **Unit tests executed by the author**

No Unit Test

## **How to test manually**

- Go to Apps Menu
- Click the `Update Apps List` button in the top part of the page and click `Update` button on the modal
- Reload the page.
- Remove the `Apps` filter in the search bar.
- in the Categories section, click the OpenSPP category.
- Check if all OpenSPP modules are included.

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/513
