### PR TITLE
hide verify eligibility button on cycle view

### DIFF
--- a/spp_manual_eligibility/__manifest__.py
+++ b/spp_manual_eligibility/__manifest__.py
@@ -18,6 +18,7 @@
     "data": [
         "views/program_view.xml",
         "views/program_membership_view.xml",
+        "views/cycle_view.xml",
         "wizard/create_program_wizard.xml",
     ],
     "assets": {},

--- a/spp_manual_eligibility/models/__init__.py
+++ b/spp_manual_eligibility/models/__init__.py
@@ -3,3 +3,4 @@
 from . import eligibility_manager
 from . import program
 from . import program_membership
+from . import cycle

--- a/spp_manual_eligibility/models/cycle.py
+++ b/spp_manual_eligibility/models/cycle.py
@@ -9,15 +9,4 @@ _logger = logging.getLogger(__name__)
 class G2PCycle(models.Model):
     _inherit = "g2p.cycle"
 
-    is_manual_eligibility = fields.Boolean(compute="_compute_is_manual_eligibility")
-
-    def _compute_is_manual_eligibility(self):
-        for rec in self:
-            is_manual_eligibility = False
-            curr_eligibility_manager = self.env["g2p.program_membership.manager.default"].search(
-                [("program_id", "=", rec.program_id.id), ("is_manual_eligibility", "=", True)]
-            )
-            if curr_eligibility_manager:
-                is_manual_eligibility = True
-
-            rec.is_manual_eligibility = is_manual_eligibility
+    is_manual_eligibility = fields.Boolean(related="program_id.is_manual_eligibility")

--- a/spp_manual_eligibility/models/cycle.py
+++ b/spp_manual_eligibility/models/cycle.py
@@ -1,0 +1,23 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+import logging
+
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class G2PCycle(models.Model):
+    _inherit = "g2p.cycle"
+
+    is_manual_eligibility = fields.Boolean(compute="_compute_is_manual_eligibility")
+
+    def _compute_is_manual_eligibility(self):
+        for rec in self:
+            is_manual_eligibility = False
+            curr_eligibility_manager = self.env["g2p.program_membership.manager.default"].search(
+                [("program_id", "=", rec.program_id.id), ("is_manual_eligibility", "=", True)]
+            )
+            if curr_eligibility_manager:
+                is_manual_eligibility = True
+
+            rec.is_manual_eligibility = is_manual_eligibility

--- a/spp_manual_eligibility/views/cycle_view.xml
+++ b/spp_manual_eligibility/views/cycle_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+-->
+<odoo>
+    <record id="view_cycle_manual_eligibility_form" model="ir.ui.view">
+        <field name="name">view_cycle_manual_eligibility_form</field>
+        <field name="model">g2p.cycle</field>
+        <field name="priority">1010</field>
+        <field name="inherit_id" ref="g2p_programs.view_cycle_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='locked']" position="before">
+                <field name="is_manual_eligibility" invisible="1" />
+            </xpath>
+            <xpath expr="//button[@name='check_eligibility']" position="attributes">
+                <attribute name="invisible">
+                    is_manual_eligibility or state not in ('draft','enrolled')
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## **Why is this change needed?**
To hide `Verify Eligibility` button on cycle view

## **How was the change implemented?**
Added an attribute on cycle view to hide `Verify Eligibility` button if Program is Manual Eligibility

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
- Install or Upgrade `spp_manual_eligibility`.
- Navigate to a Program with Manual Eligibility as the Eligibility Manager.
- Create or Open a Cycle.
- Check if `Verify Eligibility` Button is hidden.

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/533
