### PR TITLE
Remove spp helpdesk references

### DIFF
--- a/g2p_connect_demo/__manifest__.py
+++ b/g2p_connect_demo/__manifest__.py
@@ -23,7 +23,6 @@
         # "spp_dashboard",
         "spp_idpass",
         "spp_idqueue",
-        # "spp_helpdesk",
         "spp_area",
         # "spp_change_request",
         "spp_event_data",

--- a/spp_base_demo/__manifest__.py
+++ b/spp_base_demo/__manifest__.py
@@ -12,7 +12,6 @@
     "depends": [
         "g2p_registry_base",
         "g2p_programs",
-        # "spp_helpdesk",
         "product",
         "stock",
     ],

--- a/spp_demo/__manifest__.py
+++ b/spp_demo/__manifest__.py
@@ -20,7 +20,6 @@
         "spp_custom_field",
         "spp_custom_field_recompute_daily",
         "spp_idpass",
-        # "spp_helpdesk",
         "spp_area",
         "theme_openspp_muk",
         # "spp_pos",

--- a/spp_starter/wizards/spp_starter.py
+++ b/spp_starter/wizards/spp_starter.py
@@ -174,8 +174,6 @@ class SppStarter(models.TransientModel):
             res |= find_module("g2p_bank")
         if self.conducting_inkind_transfer == "yes":
             res |= find_module("spp_entitlement_in_kind")
-        if self.complaint_management == "yes":
-            res |= find_module("spp_helpdesk")
         return res
 
     def _remove_default_products_if_needed(self):


### PR DESCRIPTION
## **Why is this change needed?**
Removing stale references increases developer readability

## **How was the change implemented?**
Removed references to `spp_helpdesk`, including commented out references, from the codebase.