### PR TITLE
fix import match validation and test functionality on big data

### DIFF
--- a/spp_farmer_registry_base/__manifest__.py
+++ b/spp_farmer_registry_base/__manifest__.py
@@ -30,7 +30,11 @@
         "views/res_partner.xml",
         "views/configuration_view.xml",
     ],
-    "assets": {},
+    "assets": {
+        "web.assets_backend": [
+            "spp_farmer_registry_base/static/src/import_records/import_records.js",
+        ],
+    },
     "demo": [],
     "images": [],
     "application": False,

--- a/spp_farmer_registry_base/models/base_import.py
+++ b/spp_farmer_registry_base/models/base_import.py
@@ -11,6 +11,12 @@ class SPPBaseImport(models.TransientModel):
 
     def execute_import(self, fields, columns, options, dryrun=False):
         if self.res_model == "res.partner":
-            if "is_group" in fields and not ("farmer_given_name" in fields and "farmer_family_name" in fields):
-                raise ValidationError(_("Farmer Given Name or Farmer Family Name is required"))
+            with_is_group = False
+            if "is_group" in fields:
+                with_is_group = True
+            if "default_is_group" in self.env.context:
+                with_is_group = True
+            if with_is_group and not ("farmer_given_name" in fields and "farmer_family_name" in fields):
+                raise ValidationError(_("farmer_given_name and farmer_family_name must be present in the excel file."))
+
         return super().execute_import(fields, columns, options, dryrun=dryrun)

--- a/spp_farmer_registry_base/static/src/import_records/import_records.js
+++ b/spp_farmer_registry_base/static/src/import_records/import_records.js
@@ -1,0 +1,28 @@
+/** @odoo-module **/
+
+import {ImportRecords} from "@base_import/import_records/import_records";
+
+import {patch} from "@web/core/utils/patch";
+
+patch(ImportRecords.prototype, {
+    importRecords() {
+        const {context, resModel} = this.env.searchModel;
+        const additionalContext = {};
+        if (resModel === "res.partner") {
+            if (context.default_is_registrant) {
+                additionalContext.default_is_registrant = context.default_is_registrant;
+            }
+            if (context.default_is_group) {
+                additionalContext.default_is_group = context.default_is_group;
+            }
+            if (context.default_kind) {
+                additionalContext.default_kind = context.default_kind;
+            }
+        }
+        this.action.doAction({
+            type: "ir.actions.client",
+            tag: "import",
+            params: {model: resModel, context, additionalContext},
+        });
+    },
+});

--- a/spp_import_match/__manifest__.py
+++ b/spp_import_match/__manifest__.py
@@ -20,6 +20,7 @@
     "assets": {
         "web.assets_backend": [
             "/spp_import_match/static/src/legacy/js/custom_base_import.js",
+            "/spp_import_match/static/src/legacy/js/import_records.js",
         ],
         "web.assets_qweb": [
             "spp_import_match/static/src/legacy/xml/custom_base_import.xml",

--- a/spp_import_match/models/base_import.py
+++ b/spp_import_match/models/base_import.py
@@ -60,8 +60,23 @@ class SPPBaseImport(models.TransientModel):
             return {"messages": [error.__dict__]}
 
         _logger.info(f"Started Import: {self.res_model} with rows {len(input_file_data)}")
-        _logger.info("Number of Fields: %s" % len(fields))
-        _logger.info("Number of Columns: %s" % len(columns))
+
+        if dryrun and len(input_file_data) > 100:
+            self._cr.execute("SAVEPOINT import")
+
+            import_fields, merged_data = self._handle_multi_mapping(import_fields, input_file_data)
+
+            if options.get("fallback_values"):
+                merged_data = self._handle_fallback_values(import_fields, merged_data, options["fallback_values"])
+
+            model = self.env[self.res_model].with_context(self.env.context)
+            import_result = model.load(import_fields, merged_data[:1])
+
+            self._cr.execute("ROLLBACK TO SAVEPOINT import")
+            self.pool.clear_all_caches()
+            self.pool.reset_changes()
+            return import_result
+
         if dryrun or not len(input_file_data) > 100:
             # normal import
             _logger.info("Doing Normal Import")
@@ -94,6 +109,7 @@ class SPPBaseImport(models.TransientModel):
             translated_model_name=translated_model_name,
             attachment=attachment,
             options=options,
+            split_context=self.env.context,
             file_name=self.file_name,
         )
         self._link_attachment_to_job(delayed_job, attachment)
@@ -154,6 +170,7 @@ class SPPBaseImport(models.TransientModel):
         translated_model_name,
         attachment,
         options,
+        split_context,
         file_name="file.csv",
     ):
         """Split a CSV attachment in smaller import jobs"""
@@ -186,13 +203,13 @@ class SPPBaseImport(models.TransientModel):
                 file_name=root + "-" + chunk + ext,
             )
             delayed_job = self.with_delay(description=description, priority=priority)._import_one_chunk(
-                model_name=model_name, attachment=attachment, options=options
+                model_name=model_name, attachment=attachment, options=options, context=split_context
             )
             self._link_attachment_to_job(delayed_job, attachment)
             priority += 1
 
-    def _import_one_chunk(self, model_name, attachment, options):
-        model_obj = self.env[model_name]
+    def _import_one_chunk(self, model_name, attachment, options, context):
+        model_obj = self.env[model_name].with_context(context)
         fields, data = self._read_csv_attachment(attachment, options)
         result = model_obj.load(fields, data)
         error_message = [message["message"] for message in result["messages"] if message["type"] == "error"]

--- a/spp_import_match/static/src/legacy/js/import_records.js
+++ b/spp_import_match/static/src/legacy/js/import_records.js
@@ -1,0 +1,28 @@
+/** @odoo-module **/
+
+import {ImportRecords} from "@base_import/import_records/import_records";
+
+import {patch} from "@web/core/utils/patch";
+
+patch(ImportRecords.prototype, {
+    importRecords() {
+        const {context, resModel} = this.env.searchModel;
+        const additionalContext = {};
+        if (resModel === "res.partner") {
+            if (context.default_is_registrant) {
+                additionalContext.default_is_registrant = context.default_is_registrant;
+            }
+            if (context.default_is_group) {
+                additionalContext.default_is_group = context.default_is_group;
+            }
+            if (context.default_kind) {
+                additionalContext.default_kind = context.default_kind;
+            }
+        }
+        this.action.doAction({
+            type: "ir.actions.client",
+            tag: "import",
+            params: {model: resModel, context, additionalContext},
+        });
+    },
+});


### PR DESCRIPTION
## **Why is this change needed?**
Fix 1 - To fix the validation on Importing when is_group or is_registrant is not in the excel file.
Fix 2 - To fix the import test function on big datas excel.

## **How was the change implemented?**
Fix 1 - Added a JS to re-evaluate the context and added a patch or fix on `base.import` - `execute_import` to pass the context on queue job.
Fix 2 - Added a conditional functionality to only test at least 1 row from the big data excel if the excel is valid.

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
Fix 1
1. Navigate to Apps and Install or Upgrade `spp_farmer_registry_base`.

Test 1 - Check if import will go through even without `is_group` or `is_registrant` in the excel file
1. Navigate to Registry>Groups.
2. Import an excel or csv file without `is_group` or `is_registrant` in the fields but make sure `farmer_family_name` and `farmer_given_name` does exists in the file.
3. If imported then Test 1 is a success.

Test 2 - Check if import will not go through if `farmer_family_name` and `farmer_given_name` is not in the excel file
1. Navigate to Registry>Groups.
2. Import an excel or csv file without farmer_family_name` and `farmer_given_name` in the fields.
3. If a validation error was raised then Test 2 is a success (Note the change of validation error message).

Fix 2
1. Navigate to Apps and Install or Upgrade `spp_import_match`.
2. Go to Registry>Groups.
3. Import a record with at least 1000 rows.
4. Click Test - If the test is done and validated quickly this is a Success (Try Fix1: Test 1 and Test 2 as scenarios).

## **Related links**
Fix 1 - https://github.com/orgs/OpenSPP/projects/5/views/4?pane=issue&itemId=74597423
Fix 2 - https://github.com/orgs/OpenSPP/projects/5/views/4?pane=issue&itemId=75262734

