### PR TITLE
Pin fastapi to 0.112.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Pillow>=10.3.0
 PyLD
 bravado_core
 faker
+fastapi==0.112.2
 geojson
 jsonschema
 jwcrypto

--- a/spp_base/__manifest__.py
+++ b/spp_base/__manifest__.py
@@ -28,7 +28,7 @@
         "spp_programs",
     ],
     "external_dependencies": {
-        "python": ["numpy>=1.22.2", "urllib3>=2.2.2", "zipp>=3.19.1"]
+        "python": ["fastapi==0.112.2", "numpy>=1.22.2", "urllib3>=2.2.2", "zipp>=3.19.1"]
     },  # not directly required, pinned by Snyk to avoid a vulnerability
     "data": [
         "security/ir.model.access.csv",


### PR DESCRIPTION
## **Why is this change needed?**
There are breaking changes in fastapi 0.112.3 and later, so I am pinning this to the last working version.

## **How was the change implemented?**
The version of fastapi has been pinned to 0.112.2.
This was done in `spp_base` to ensure the manifestoo tools picks this up when the OpenSPP-modules builds are running. On the todo-list is to update the dependencies of other repos, where `fastapi` is a direct dependency.

## **Related links**
https://github.com/fastapi/fastapi/releases