### PR TITLE
Remove VCI and Security from the build actions

### DIFF
--- a/.github/workflows/test-legacy.yml
+++ b/.github/workflows/test-legacy.yml
@@ -71,8 +71,6 @@ jobs:
         run: git clone https://github.com/OpenG2P/openg2p-program.git --depth 1 --branch 17.0-develop
       - name: Clone OpenG2P Security Repository
         run: git clone https://github.com/OpenG2P/openg2p-security.git --depth 1 --branch 17.0-develop
-      - name: Clone OpenG2P VCI Repository
-        run: git clone https://github.com/OpenG2P/openg2p-vci.git --depth 1 --branch 17.0-develop
       - name: Clone Muk Addons Repository
         run: git clone https://github.com/muk-it/odoo-modules.git --depth 1 --branch 17.0
       - name: Remove g2p_connect_demo from openspp-modules as it is not compatible with all OpenSPP variants

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,8 +102,6 @@ jobs:
         run: git clone https://github.com/OpenSPP/openg2p-program.git --depth 1 --branch 17.0-develop-openspp
       - name: Clone OpenG2P Security Repository
         run: git clone https://github.com/OpenSPP/openg2p-security.git --depth 1 --branch 17.0-develop-openspp
-      - name: Clone OpenG2P VCI Repository
-        run: git clone https://github.com/OpenSPP/openg2p-vci.git --depth 1 --branch 17.0-develop-openspp
       - name: Clone Muk Addons Repository
         run: git clone https://github.com/OpenSPP/mukit-modules.git --depth 1 --branch 17.0-openspp
       - name: Copy OpenG2P modules to addons directory, remove tests and unsupported modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,18 +100,18 @@ jobs:
         run: git clone https://github.com/OpenSPP/openg2p-registry.git --depth 1 --branch 17.0-develop-openspp
       - name: Clone OpenG2P Programs Repository
         run: git clone https://github.com/OpenSPP/openg2p-program.git --depth 1 --branch 17.0-develop-openspp
-      - name: Clone OpenG2P Security Repository
-        run: git clone https://github.com/OpenSPP/openg2p-security.git --depth 1 --branch 17.0-develop-openspp
       - name: Clone Muk Addons Repository
         run: git clone https://github.com/OpenSPP/mukit-modules.git --depth 1 --branch 17.0-openspp
       - name: Copy OpenG2P modules to addons directory, remove tests and unsupported modules
         run: |
           rm -rf openg2p-registry/*/tests
           rm -rf openg2p-registry/g2p_documents
+          rm -rf openg2p-registry/g2p_encryption_keymanager
           rm -rf openg2p-registry/g2p_odk_importer
           rm -rf openg2p-registry/g2p_odk_user_mapping
           rm -rf openg2p-registry/g2p_profile_image
           rm -rf openg2p-registry/g2p_registry_documents
+          rm -rf openg2p-registry/g2p_registry_encryption
           rm -rf openg2p-program/*/tests
           rm -rf openg2p-program/g2p_entitlement_voucher
           rm -rf openg2p-program/g2p_odk_importer_program
@@ -120,22 +120,13 @@ jobs:
           rm -rf openg2p-program/g2p_payment_cash
           rm -rf openg2p-program/g2p_payment_g2p_connect
           rm -rf openg2p-program/g2p_program_documents
-          rm -rf openg2p-security/*/tests
-          rm -rf openg2p-security/g2p_encryption_keymanager
-          rm -rf openg2p-security/g2p_registry_encryption
-          rm -rf openg2p-storage/*/tests
-          rm -rf openg2p-vci/*/tests
           rm -rf mukit-modules/muk_web_enterprise_theme
           cp -r openg2p-registry/* ${ADDONS_DIR}/
           cat test-requirements.txt >> spp-test-requirements.txt
           cp -r openg2p-program/* ${ADDONS_DIR}/
           cat test-requirements.txt >> spp-test-requirements.txt
-          cp -r openg2p-security/* ${ADDONS_DIR}/
-          cat test-requirements.txt >> spp-test-requirements.txt
           # cp -r openg2p-storage/* ${ADDONS_DIR}/
           # cat test-requirements.txt >> spp-test-requirements.txt
-          cp -r openg2p-vci/* ${ADDONS_DIR}/
-          cat test-requirements.txt >> spp-test-requirements.txt
           # MUK Addons
           cp -r mukit-modules/* ${ADDONS_DIR}/
       - name: Add g2p-programs and odoo-test-helper to spp-test-requirements.txt


### PR DESCRIPTION
## **Why is this change needed?**
As OpenG2P have moved the VCI addons from the openg2p-vci repo to the openg2-registry repo, we should no longer clone the openg2p-vci repo during the build.

The addons in the openg2p-security repo have also been moved to the openg2p-registry repo.

## **How was the change implemented?**
The cloning of the openg2p-vci and openg2p-security repos have been removed.

## **Related links**
OpenG2P-registry commit which adds the addons `g2p_openid_vci_rest_api` and `g2p_openid_vci` which were originally found in https://github.com/OpenG2P/openg2p-vci to https://github.com/OpenG2P/openg2p-registry

https://github.com/OpenG2P/openg2p-registry/commit/ca2a73c0d970eeee93139223fa9134ad8875ca73