### PR TITLE
minor fix on base import

### DIFF
--- a/spp_farmer_registry_base/models/base_import.py
+++ b/spp_farmer_registry_base/models/base_import.py
@@ -15,7 +15,14 @@ class SPPBaseImport(models.TransientModel):
             if "is_group" in fields:
                 with_is_group = True
             if "default_is_group" in self.env.context:
-                with_is_group = True
+                if self.env.context["default_is_group"]:
+                    with_is_group = True
+            if "default_kind" in self.env.context:
+                if self.env.context["default_kind"] == self.env.ref("spp_farmer_registry_base.kind_farm").id:
+                    with_is_group = True
+                else:
+                    with_is_group = False
+
             if with_is_group and not ("farmer_given_name" in fields and "farmer_family_name" in fields):
                 raise ValidationError(_("farmer_given_name and farmer_family_name must be present in the excel file."))
 


### PR DESCRIPTION
## **Why is this change needed?**
To fix the issue where a validation error is being raised for farmer names on Individual and Farm Groups import.

## **How was the change implemented?**
Added a condition in the base import to ignore checking if the registrant is Farm Group or Individual.

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
- Install or Upgrade `spp_farmer_registry_base`.
- Try importing a farm group or individual without farmer family and given name on the excel file.
- If no error was raised, then this PR is good.

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/515
