### PR TITLE
added OpenSPP category to spp_cutom_filter and spp_custom_filter_ui

### DIFF
--- a/spp_custom_filter/__manifest__.py
+++ b/spp_custom_filter/__manifest__.py
@@ -1,5 +1,6 @@
 {
     "name": "OpenSPP Custom Filter",
+    "category": "OpenSPP",
     "version": "17.0.1.0.0",
     "summary": "Enhances Odoo's filtering system by allowing administrators to control which fields are displayed in filter dropdowns, improving user experience and data management.",
     "author": "OpenSPP.org",

--- a/spp_custom_filter_ui/__manifest__.py
+++ b/spp_custom_filter_ui/__manifest__.py
@@ -1,5 +1,6 @@
 {
     "name": "OpenSPP Custom Filter UI",
+    "category": "OpenSPP",
     "version": "17.0.1.0.0",
     "summary": "Customizes the OpenSPP UI to enhance filtering for Res Partners, improving usability and efficiency in managing registrants within social protection programs.",
     "author": "OpenSPP.org",


### PR DESCRIPTION
## **Why is this change needed?**

both `OpenSPP Custom Filter` and `OpenSPP Custom Filter UI` is not included in the OpenSPP category filter.

## **How was the change implemented?**

Added `OpenSPP` in the manifest.py file of both spp_custom_filter and spp_custom_filter_ui modules

## **New unit tests**

None

## **Unit tests executed by the author**

None

## **How to test manually**

- Go to Apps Menu
- Click the `Update Apps List` button in the top part of the page and click `Update` button on the modal
- Reload the page.
- Remove the `Apps` filter in the search bar.
- in the Categories section, click the OpenSPP category.
- Check if all OpenSPP modules are included.

## **Related links**

https://github.com/OpenSPP/openspp-modules/issues/513
