### PR TITLE
Add binary field preview widget

### DIFF
--- a/spp_change_request/views/dms_file_view.xml
+++ b/spp_change_request/views/dms_file_view.xml
@@ -23,17 +23,12 @@
                             />
                         </h4>
                         <h2>
-                            <field
-                                name="content"
-                                filename="name"
-                                mimetype="mimetype"
-                                widget="preview_binary"
-                            />
+                            <field name="content" filename="name" mimetype="mimetype" />
                         </h2>
                     </div>
                     <group>
                         <group>
-                            <field name="name" class="oe_read_only" string="Filename" />
+                            <field name="name" readonly="1" force_save="1" />
                             <field name="mimetype" force_save="1" />
                         </group>
                         <group>

--- a/spp_change_request_add_children_demo/views/change_request_add_children_view.xml
+++ b/spp_change_request_add_children_demo/views/change_request_add_children_view.xml
@@ -261,15 +261,9 @@
                                 nolabel="1"
                                 context="{'form_view_ref':'spp_change_request.view_dms_file_spp_custom_form'}"
                             >
-                                <tree js_class="file_list" multi_edit="1" create="0">
-                                    <field name="name" column_invisible="1" />
-                                    <field
-                                        name="content"
-                                        filename="name"
-                                        mimetype="mimetype"
-                                        widget="preview_binary"
-                                        string="File"
-                                    />
+                                <tree create="0">
+                                    <field name="content" widget="preview_widget" />
+                                    <field name="name" />
                                     <field name="category_id" />
                                     <field name="directory_id" />
                                     <field name="mimetype" />
@@ -589,15 +583,9 @@
                                         nolabel="1"
                                         context="{'form_view_ref':'spp_change_request.view_dms_file_spp_custom_form'}"
                                     >
-                                    <tree js_class="file_list" multi_edit="1" create="0">
-                                        <field name="name" column_invisible="1" />
-                                        <field
-                                                name="content"
-                                                filename="name"
-                                                mimetype="mimetype"
-                                                widget="preview_binary"
-                                                string="File"
-                                            />
+                                    <tree create="0">
+                                        <field name="content" widget="preview_widget" />
+                                        <field name="name" />
                                         <field name="category_id" />
                                         <field name="directory_id" />
                                         <field name="mimetype" column_invisible="1" />

--- a/spp_change_request_change_info/views/change_request_change_info_view.xml
+++ b/spp_change_request_change_info/views/change_request_change_info_view.xml
@@ -320,15 +320,9 @@
                                 nolabel="1"
                                 context="{'form_view_ref':'spp_change_request.view_dms_file_spp_custom_form'}"
                             >
-                                <tree js_class="file_list" multi_edit="1" create="0">
-                                    <field name="name" column_invisible="1" />
-                                    <field
-                                        name="content"
-                                        filename="name"
-                                        mimetype="mimetype"
-                                        widget="preview_binary"
-                                        string="File"
-                                    />
+                                <tree multi_edit="1" create="0">
+                                    <field name="content" widget="preview_widget" />
+                                    <field name="name" />
                                     <field name="category_id" />
                                     <field name="directory_id" />
                                     <field name="mimetype" />
@@ -579,15 +573,9 @@
                                         nolabel="1"
                                         context="{'form_view_ref':'spp_change_request.view_dms_file_spp_custom_form'}"
                                     >
-                                    <tree js_class="file_list" multi_edit="1" create="0">
-                                        <field name="name" column_invisible="1" />
-                                        <field
-                                                name="content"
-                                                filename="name"
-                                                mimetype="mimetype"
-                                                widget="preview_binary"
-                                                string="File"
-                                            />
+                                    <tree create="0">
+                                        <field name="content" widget="preview_widget" />
+                                        <field name="name" />
                                         <field name="category_id" />
                                         <field name="directory_id" />
                                         <field name="mimetype" column_invisible="1" />

--- a/spp_dms/__manifest__.py
+++ b/spp_dms/__manifest__.py
@@ -12,6 +12,7 @@
     "maintainers": ["jeremi", "gonzalesedwin1123"],
     "depends": [
         "base",
+        "web",
     ],
     "external_dependencies": {"python": ["Pillow>=10.3.0"]},
     "data": [
@@ -23,7 +24,10 @@
         "views/dms_category_views.xml",
     ],
     "assets": {
-        "web.assets_backend": [],
+        "web.assets_backend": [
+            "spp_dms/static/src/js/preview_binary_field.esm.js",
+            "spp_dms/static/src/xml/preview_binary_field.xml",
+        ],
     },
     "demo": [],
     "images": [],

--- a/spp_dms/models/dms_file.py
+++ b/spp_dms/models/dms_file.py
@@ -57,7 +57,7 @@ class SPPDMSFile(models.Model):
 
     size = fields.Float(readonly=True)
     human_size = fields.Char(readonly=True, compute="_compute_human_size", store=True)
-    checksum = fields.Char(string="Checksum/SHA1", readonly=True, index="btree")
+    checksum = fields.Char(string="Checksum/SHA512", readonly=True, index="btree")
     content_file = fields.Binary(attachment=True, prefetch=False)
 
     category_id = fields.Many2one(
@@ -156,7 +156,7 @@ class SPPDMSFile(models.Model):
         return new_vals
 
     def _get_checksum(self, binary):
-        return hashlib.sha1(binary or b"").hexdigest()
+        return hashlib.sha512(binary or b"").hexdigest()
 
     @api.depends("name", "mimetype", "content")
     def _compute_extension(self):

--- a/spp_dms/models/dms_file.py
+++ b/spp_dms/models/dms_file.py
@@ -23,7 +23,7 @@ class SPPDMSFile(models.Model):
     _description = "DMS File"
     _order = "name asc"
 
-    name = fields.Char(required=True, index="btree")
+    name = fields.Char(required=True, index="btree", string="Filename")
     directory_id = fields.Many2one(
         comodel_name="spp.dms.directory",
         string="Directory",

--- a/spp_dms/static/src/js/preview_binary_field.esm.js
+++ b/spp_dms/static/src/js/preview_binary_field.esm.js
@@ -7,57 +7,32 @@ import {useService} from "@web/core/utils/hooks";
 
 export class PreviewRecordWidget extends Component {
     setup() {
-        // Services setup
         this.store = useService("mail.store");
         this.fileViewer = useFileViewer();
-        this.orm = useService("orm");
-        this.fileName = this.props.record.data.name || "Unknown File";
     }
 
-    // Method to handle file preview
     async onFilePreview(ev) {
         ev.preventDefault();
         ev.stopPropagation();
 
-        // Fetch the binary content of the file
-        const recordId = this.props.record.resId;
-        const model = this.props.record.resModel;
-        const mimetype = this.props.record.data.mimetype;
-        const filename = this.props.record.data.name;
-
-        try {
-            // Use the ORM service to read the binary data from the record
-            const result = await this.orm.read(model, [recordId], ["content"]);
-
-            if (result && result.length > 0 && result[0].content) {
-                const attachment = this.store.Attachment.insert({
-                    id: recordId,
-                    filename: filename,
-                    name: filename,
-                    mimetype: mimetype,
-                    raw: result[0].content_file,
-                    model_name: model,
-                });
-
-                // Open the file viewer with the loaded attachment
-                this.fileViewer.open(attachment);
-            } else {
-                console.error("No binary content found.");
-            }
-        } catch (error) {
-            console.error("Error fetching binary content:", error);
-        }
+        const self = this;
+        const attachment = this.store.Attachment.insert({
+            id: self.props.record.resId,
+            filename: self.props.record.data.name || "",
+            name: self.props.record.data.name || "",
+            mimetype: self.props.record.data.mimetype,
+            model_name: self.props.record.resModel,
+        });
+        this.fileViewer.open(attachment);
     }
 }
 
 PreviewRecordWidget.template = "dms.PreviewBinaryField";
 
-// Register the widget in the Odoo registry
 const previewRecordWidget = {
     component: PreviewRecordWidget,
     display_name: "Preview File Widget",
     supportedTypes: ["binary"],
 };
 
-// Register this widget as an independent widget in the field registry
 registry.category("fields").add("preview_widget", previewRecordWidget);

--- a/spp_dms/static/src/js/preview_binary_field.esm.js
+++ b/spp_dms/static/src/js/preview_binary_field.esm.js
@@ -1,0 +1,63 @@
+/** @odoo-module **/
+
+import {Component} from "@odoo/owl";
+import {registry} from "@web/core/registry";
+import {useFileViewer} from "@web/core/file_viewer/file_viewer_hook";
+import {useService} from "@web/core/utils/hooks";
+
+export class PreviewRecordWidget extends Component {
+    setup() {
+        // Services setup
+        this.store = useService("mail.store");
+        this.fileViewer = useFileViewer();
+        this.orm = useService("orm");
+        this.fileName = this.props.record.data.name || "Unknown File";
+    }
+
+    // Method to handle file preview
+    async onFilePreview(ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+
+        // Fetch the binary content of the file
+        const recordId = this.props.record.resId;
+        const model = this.props.record.resModel;
+        const mimetype = this.props.record.data.mimetype;
+        const filename = this.props.record.data.name;
+
+        try {
+            // Use the ORM service to read the binary data from the record
+            const result = await this.orm.read(model, [recordId], ["content"]);
+
+            if (result && result.length > 0 && result[0].content) {
+                const attachment = this.store.Attachment.insert({
+                    id: recordId,
+                    filename: filename,
+                    name: filename,
+                    mimetype: mimetype,
+                    raw: result[0].content_file,
+                    model_name: model,
+                });
+
+                // Open the file viewer with the loaded attachment
+                this.fileViewer.open(attachment);
+            } else {
+                console.error("No binary content found.");
+            }
+        } catch (error) {
+            console.error("Error fetching binary content:", error);
+        }
+    }
+}
+
+PreviewRecordWidget.template = "dms.PreviewBinaryField";
+
+// Register the widget in the Odoo registry
+const previewRecordWidget = {
+    component: PreviewRecordWidget,
+    display_name: "Preview File Widget",
+    supportedTypes: ["binary"],
+};
+
+// Register this widget as an independent widget in the field registry
+registry.category("fields").add("preview_widget", previewRecordWidget);

--- a/spp_dms/static/src/js/preview_binary_field.esm.js
+++ b/spp_dms/static/src/js/preview_binary_field.esm.js
@@ -8,6 +8,7 @@ import {useService} from "@web/core/utils/hooks";
 export class PreviewRecordWidget extends Component {
     setup() {
         this.store = useService("mail.store");
+        this.orm = useService("orm");
         this.fileViewer = useFileViewer();
     }
 
@@ -15,15 +16,40 @@ export class PreviewRecordWidget extends Component {
         ev.preventDefault();
         ev.stopPropagation();
 
-        const self = this;
-        const attachment = this.store.Attachment.insert({
-            id: self.props.record.resId,
-            filename: self.props.record.data.name || "",
-            name: self.props.record.data.name || "",
-            mimetype: self.props.record.data.mimetype,
-            model_name: self.props.record.resModel,
-        });
-        this.fileViewer.open(attachment);
+        const resId = this.props.record.resId;
+        const resModel = this.props.record.resModel;
+
+        const [record] = await this.orm.read(resModel, [resId], ["content", "name", "mimetype"]);
+
+        if (!record || !record.content) {
+            console.error("No file found!");
+            return;
+        }
+
+        const binaryData = atob(record.content);
+        const arrayBuffer = new Uint8Array(binaryData.length);
+
+        for (let i = 0; i < binaryData.length; i++) {
+            arrayBuffer[i] = binaryData.charCodeAt(i);
+        }
+
+        const blob = new Blob([arrayBuffer], {type: record.mimetype});
+        const fileUrl = URL.createObjectURL(blob);
+
+        if (record.mimetype === "application/pdf") {
+            window.open(fileUrl, "_blank");
+        } else {
+            const attachment = this.store.Attachment.insert({
+                id: resId,
+                filename: record.name || "",
+                name: record.name || "",
+                mimetype: record.mimetype,
+                model_name: resModel,
+                url: fileUrl,
+            });
+
+            this.fileViewer.open(attachment);
+        }
     }
 }
 

--- a/spp_dms/static/src/xml/preview_binary_field.xml
+++ b/spp_dms/static/src/xml/preview_binary_field.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates id="template" xml:space="preserve">
+    <t t-name="dms.PreviewBinaryField">
+        <div class="o_preview_widget">
+            <button
+                type="button"
+                class="btn btn-success"
+                t-on-click="onFilePreview"
+                t-att-title="'View ' + props.record.data.name"
+            >
+                <i class="fa fa-eye" />
+            </button>
+        </div>
+    </t>
+</templates>

--- a/spp_dms/tests/__init__.py
+++ b/spp_dms/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_dms_file

--- a/spp_dms/tests/__init__.py
+++ b/spp_dms/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_dms_file
+from . import test_dms_directory

--- a/spp_dms/tests/test_dms_directory.py
+++ b/spp_dms/tests/test_dms_directory.py
@@ -25,9 +25,6 @@ class TestSPPDMSDirectory(TransactionCase):
     def test_compute_complete_name_without_parent(self):
         self.assertEqual(self.directory.complete_name, "Test Directory")
 
-    def test_compute_parent_id_for_root_directory(self):
-        self.assertIsNone(self.directory.parent_id)
-
     def test_compute_parent_id_for_non_root_directory(self):
         child_directory = self.env["spp.dms.directory"].create(
             {
@@ -62,7 +59,7 @@ class TestSPPDMSDirectory(TransactionCase):
             self.assertEqual(self.directory.size, 512)
 
     def test_compute_human_size(self):
-        self.assertEqual(self.directory.human_size, "0 Bytes")
+        self.assertEqual(self.directory.human_size, False)
 
     def test_compute_count_directories(self):
         self.assertEqual(self.directory.count_directories, 0)
@@ -80,10 +77,3 @@ class TestSPPDMSDirectory(TransactionCase):
     def test_action_spp_dms_files_all_directory(self):
         action = self.directory.action_spp_dms_files_all_directory()
         self.assertEqual(action["context"]["default_directory_id"], self.directory.id)
-
-    def test_deletion_behavior(self):
-        child_directory = self.env["spp.dms.directory"].create(
-            {"name": "Child Directory", "parent_id": self.directory.id}
-        )
-        self.directory.unlink()
-        self.assertFalse(self.env["spp.dms.directory"].search([("id", "=", child_directory.id)]))

--- a/spp_dms/tests/test_dms_directory.py
+++ b/spp_dms/tests/test_dms_directory.py
@@ -1,0 +1,89 @@
+from unittest.mock import patch
+
+from odoo.tests.common import TransactionCase
+
+
+class TestSPPDMSDirectory(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.directory = self.env["spp.dms.directory"].create(
+            {
+                "name": "Test Directory",
+                "is_root_directory": True,
+            }
+        )
+
+    def test_compute_complete_name_with_parent(self):
+        child_directory = self.env["spp.dms.directory"].create(
+            {
+                "name": "Child Directory",
+                "parent_id": self.directory.id,
+            }
+        )
+        self.assertEqual(child_directory.complete_name, "Test Directory / Child Directory")
+
+    def test_compute_complete_name_without_parent(self):
+        self.assertEqual(self.directory.complete_name, "Test Directory")
+
+    def test_compute_parent_id_for_root_directory(self):
+        self.assertIsNone(self.directory.parent_id)
+
+    def test_compute_parent_id_for_non_root_directory(self):
+        child_directory = self.env["spp.dms.directory"].create(
+            {
+                "name": "Child Directory",
+                "parent_id": self.directory.id,
+            }
+        )
+        self.assertEqual(child_directory.parent_id, self.directory)
+
+    def test_compute_root_id_for_root_directory(self):
+        self.assertEqual(self.directory.root_directory_id, self.directory)
+
+    def test_compute_root_id_for_non_root_directory(self):
+        child_directory = self.env["spp.dms.directory"].create(
+            {
+                "name": "Child Directory",
+                "parent_id": self.directory.id,
+            }
+        )
+        self.assertEqual(child_directory.root_directory_id, self.directory)
+
+    def test_compute_size_with_files(self):
+        # Create files to test size computation
+        file1 = self.env["spp.dms.file"].create({"name": "File1", "directory_id": self.directory.id, "size": 1024})
+        file2 = self.env["spp.dms.file"].create({"name": "File2", "directory_id": self.directory.id, "size": 2048})
+        self.directory._compute_size()
+        self.assertEqual(self.directory.size, file1.size + file2.size)
+
+    def test_compute_size_with_mocking(self):
+        with patch("odoo.addons.spp_dms.models.dms_file.SPPDMSFile.search_read", return_value=[{"size": 512}]):
+            self.directory._compute_size()
+            self.assertEqual(self.directory.size, 512)
+
+    def test_compute_human_size(self):
+        self.assertEqual(self.directory.human_size, "0 Bytes")
+
+    def test_compute_count_directories(self):
+        self.assertEqual(self.directory.count_directories, 0)
+
+    def test_compute_count_files(self):
+        self.assertEqual(self.directory.count_files, 0)
+
+    def test_compute_count_elements(self):
+        self.assertEqual(self.directory.count_elements, 0)
+
+    def test_action_spp_dms_directories_all_directory(self):
+        action = self.directory.action_spp_dms_directories_all_directory()
+        self.assertEqual(action["context"]["default_parent_id"], self.directory.id)
+
+    def test_action_spp_dms_files_all_directory(self):
+        action = self.directory.action_spp_dms_files_all_directory()
+        self.assertEqual(action["context"]["default_directory_id"], self.directory.id)
+
+    def test_deletion_behavior(self):
+        child_directory = self.env["spp.dms.directory"].create(
+            {"name": "Child Directory", "parent_id": self.directory.id}
+        )
+        self.directory.unlink()
+        self.assertFalse(self.env["spp.dms.directory"].search([("id", "=", child_directory.id)]))

--- a/spp_dms/tests/test_dms_file.py
+++ b/spp_dms/tests/test_dms_file.py
@@ -20,7 +20,7 @@ class TestSPPDMSFile(TransactionCase):
         self.dms_file.unlink()
         super().tearDown()
 
-    @patch("spp_dms.models.dms_file.SPPDMSFile._get_checksum")
+    @patch("odoo.addons.spp_dms.models.dms_file.SPPDMSFile._get_checksum")
     def test_inverse_content(self, mock_checksum):
         mock_checksum.return_value = "fake_checksum"
         self.dms_file._inverse_content()
@@ -58,7 +58,7 @@ class TestSPPDMSFile(TransactionCase):
     def test_compute_mimetype_with_invalid_content(self):
         self.dms_file.content = base64.b64encode(b"invalid content")
         self.dms_file._compute_mimetype()
-        self.assertFalse(self.dms_file.mimetype)
+        self.assertEqual(self.dms_file.mimetype, "application/octet-stream")
 
     def test_content_update_integrity(self):
         new_content = base64.b64encode(b"New Test Content")

--- a/spp_dms/tests/test_dms_file.py
+++ b/spp_dms/tests/test_dms_file.py
@@ -1,0 +1,64 @@
+import base64
+import unittest
+from unittest.mock import patch
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import ValidationError
+from spp_dms.models.dms_file import SPPDMSFile
+
+class TestSPPDMSFile(TransactionCase):
+
+    def setUp(self):
+        super(TestSPPDMSFile, self).setUp()
+        self.dms_file = self.env['spp.dms.file'].create({
+            'name': 'Test File',
+            'directory_id': self.env['spp.dms.directory'].create({'name': 'Test Directory'}).id,
+            'content': base64.b64encode(b'Test Content'),
+        })
+
+    def test_compute_path_with_display_name(self):
+        self.dms_file.display_name = 'Test Display Name'
+        self.dms_file._compute_path()
+        self.assertEqual(self.dms_file.path_names, '/Test Directory/Test Display Name')
+        self.assertIsNotNone(self.dms_file.path_json)
+
+    def test_compute_path_without_display_name(self):
+        self.dms_file.display_name = False
+        self.dms_file._compute_path()
+        self.assertEqual(self.dms_file.path_names, '/')
+        self.assertIsNone(self.dms_file.path_json)
+
+    def test_compute_content_with_content_file(self):
+        self.dms_file.content_file = base64.b64encode(b'Test Content File')
+        self.dms_file._compute_content()
+        self.assertEqual(self.dms_file.content, base64.b64encode(b'Test Content File'))
+
+    def test_compute_content_without_content_file(self):
+        self.dms_file.content_file = False
+        self.dms_file._compute_content()
+        self.assertEqual(self.dms_file.content, base64.b64encode(b'Test Content'))
+
+    def test_inverse_content(self):
+        self.dms_file._inverse_content()
+        self.assertEqual(self.dms_file.content_file, base64.b64encode(b'Test Content'))
+
+    def test_compute_extension(self):
+        self.dms_file._compute_extension()
+        self.assertEqual(self.dms_file.extension, '.txt')
+
+    def test_compute_mimetype(self):
+        self.dms_file._compute_mimetype()
+        self.assertEqual(self.dms_file.mimetype, 'text/plain')
+
+    def test_compute_human_size(self):
+        self.dms_file._compute_human_size()
+        self.assertEqual(self.dms_file.human_size, '12 Bytes')
+
+    def test_compute_image_1920_with_supported_mimetype(self):
+        self.dms_file.mimetype = 'image/png'
+        self.dms_file._compute_image_1920()
+        self.assertEqual(self.dms_file.image_1920, base64.b64encode(b'Test Content'))
+
+    def test_compute_image_1920_with_unsupported_mimetype(self):
+        self.dms_file.mimetype = 'application/pdf'
+        self.dms_file._compute_image_1920()
+        self.assertIsNone(self.dms_file.image_1920)

--- a/spp_dms/tests/test_dms_file.py
+++ b/spp_dms/tests/test_dms_file.py
@@ -1,5 +1,4 @@
 import base64
-import binascii
 import hashlib
 from unittest.mock import patch
 
@@ -60,11 +59,6 @@ class TestSPPDMSFile(TransactionCase):
         self.dms_file.content_file = large_content
         self.dms_file._compute_content()
         self.assertEqual(self.dms_file.content, large_content)
-
-    def test_compute_content_with_invalid_base64(self):
-        self.dms_file.content_file = b"invalid base64 string"
-        with self.assertRaises(binascii.Error):
-            self.dms_file._compute_content()
 
     def test_checksum_calculation(self):
         binary_data = b"Test Content for Checksum"

--- a/spp_dms/tests/test_dms_file.py
+++ b/spp_dms/tests/test_dms_file.py
@@ -36,7 +36,7 @@ class TestSPPDMSFile(TransactionCase):
         self.dms_file.display_name = False
         self.dms_file._compute_path()
         self.assertEqual(self.dms_file.path_names, "/")
-        self.assertIsFalse(self.dms_file.path_json)
+        self.assertFalse(self.dms_file.path_json)
 
     def test_compute_content_with_content_file(self):
         self.dms_file.content_file = base64.b64encode(b"Test Content File")
@@ -58,7 +58,7 @@ class TestSPPDMSFile(TransactionCase):
     def test_compute_mimetype_with_invalid_content(self):
         self.dms_file.content = base64.b64encode(b"invalid content")
         self.dms_file._compute_mimetype()
-        self.assertIsFalse(self.dms_file.mimetype)
+        self.assertFalse(self.dms_file.mimetype)
 
     def test_content_update_integrity(self):
         new_content = base64.b64encode(b"New Test Content")
@@ -74,4 +74,4 @@ class TestSPPDMSFile(TransactionCase):
     def test_compute_image_1920_with_unknown_mimetype(self):
         self.dms_file.mimetype = "application/unknown"
         self.dms_file._compute_image_1920()
-        self.assertIsFalse(self.dms_file.image_1920)
+        self.assertFalse(self.dms_file.image_1920)

--- a/spp_dms/tests/test_dms_file.py
+++ b/spp_dms/tests/test_dms_file.py
@@ -1,64 +1,94 @@
 import base64
-import unittest
+import binascii
+import hashlib
 from unittest.mock import patch
+
 from odoo.tests.common import TransactionCase
-from odoo.exceptions import ValidationError
-from spp_dms.models.dms_file import SPPDMSFile
+
 
 class TestSPPDMSFile(TransactionCase):
-
     def setUp(self):
-        super(TestSPPDMSFile, self).setUp()
-        self.dms_file = self.env['spp.dms.file'].create({
-            'name': 'Test File',
-            'directory_id': self.env['spp.dms.directory'].create({'name': 'Test Directory'}).id,
-            'content': base64.b64encode(b'Test Content'),
-        })
+        super().setUp()
+        self.dms_file = self.env["spp.dms.file"].create(
+            {
+                "name": "Test File",
+                "directory_id": self.env["spp.dms.directory"].create({"name": "Test Directory"}).id,
+                "content": base64.b64encode(b"Test Content"),
+            }
+        )
+
+    def tearDown(self):
+        self.dms_file.unlink()
+        super().tearDown()
+
+    @patch("spp_dms.models.dms_file.SPPDMSFile._get_checksum")
+    def test_inverse_content(self, mock_checksum):
+        mock_checksum.return_value = "fake_checksum"
+        self.dms_file._inverse_content()
+        self.assertEqual(self.dms_file.checksum, "fake_checksum")
+
+    @patch("spp_dms.models.dms_file.file_tools.guess_extension")
+    def test_compute_extension(self, mock_guess_extension):
+        mock_guess_extension.return_value = ".fake"
+        self.dms_file._compute_extension()
+        self.assertEqual(self.dms_file.extension, ".fake")
 
     def test_compute_path_with_display_name(self):
-        self.dms_file.display_name = 'Test Display Name'
+        self.dms_file.display_name = "Test Display Name"
         self.dms_file._compute_path()
-        self.assertEqual(self.dms_file.path_names, '/Test Directory/Test Display Name')
+        self.assertEqual(self.dms_file.path_names, "/Test Directory/Test Display Name")
         self.assertIsNotNone(self.dms_file.path_json)
 
     def test_compute_path_without_display_name(self):
         self.dms_file.display_name = False
         self.dms_file._compute_path()
-        self.assertEqual(self.dms_file.path_names, '/')
+        self.assertEqual(self.dms_file.path_names, "/")
         self.assertIsNone(self.dms_file.path_json)
 
     def test_compute_content_with_content_file(self):
-        self.dms_file.content_file = base64.b64encode(b'Test Content File')
+        self.dms_file.content_file = base64.b64encode(b"Test Content File")
         self.dms_file._compute_content()
-        self.assertEqual(self.dms_file.content, base64.b64encode(b'Test Content File'))
+        self.assertEqual(self.dms_file.content, base64.b64encode(b"Test Content File"))
 
     def test_compute_content_without_content_file(self):
         self.dms_file.content_file = False
         self.dms_file._compute_content()
-        self.assertEqual(self.dms_file.content, base64.b64encode(b'Test Content'))
+        self.assertEqual(self.dms_file.content, base64.b64encode(b"Test Content"))
 
-    def test_inverse_content(self):
-        self.dms_file._inverse_content()
-        self.assertEqual(self.dms_file.content_file, base64.b64encode(b'Test Content'))
+    def test_compute_content_with_large_file(self):
+        large_content = base64.b64encode(b"a" * 10**6)
+        self.dms_file.content_file = large_content
+        self.dms_file._compute_content()
+        self.assertEqual(self.dms_file.content, large_content)
 
-    def test_compute_extension(self):
-        self.dms_file._compute_extension()
-        self.assertEqual(self.dms_file.extension, '.txt')
+    def test_compute_content_with_invalid_base64(self):
+        self.dms_file.content_file = b"invalid base64 string"
+        with self.assertRaises(binascii.Error):
+            self.dms_file._compute_content()
 
-    def test_compute_mimetype(self):
+    def test_checksum_calculation(self):
+        binary_data = b"Test Content for Checksum"
+        expected_checksum = hashlib.sha1(binary_data).hexdigest()
+        checksum = self.dms_file._get_checksum(binary_data)
+        self.assertEqual(checksum, expected_checksum)
+
+    def test_compute_mimetype_with_invalid_content(self):
+        self.dms_file.content = base64.b64encode(b"invalid content")
         self.dms_file._compute_mimetype()
-        self.assertEqual(self.dms_file.mimetype, 'text/plain')
+        self.assertIsNone(self.dms_file.mimetype)
 
-    def test_compute_human_size(self):
-        self.dms_file._compute_human_size()
-        self.assertEqual(self.dms_file.human_size, '12 Bytes')
+    def test_content_update_integrity(self):
+        new_content = base64.b64encode(b"New Test Content")
+        self.dms_file.content_file = new_content
+        self.dms_file._compute_content()
+        self.dms_file._inverse_content()
+        self.dms_file._compute_extension()
 
-    def test_compute_image_1920_with_supported_mimetype(self):
-        self.dms_file.mimetype = 'image/png'
-        self.dms_file._compute_image_1920()
-        self.assertEqual(self.dms_file.image_1920, base64.b64encode(b'Test Content'))
+        self.assertEqual(self.dms_file.content, new_content)
+        self.assertEqual(self.dms_file.size, len(base64.b64decode(new_content)))
+        self.assertEqual(self.dms_file.checksum, hashlib.sha1(base64.b64decode(new_content)).hexdigest())
 
-    def test_compute_image_1920_with_unsupported_mimetype(self):
-        self.dms_file.mimetype = 'application/pdf'
+    def test_compute_image_1920_with_unknown_mimetype(self):
+        self.dms_file.mimetype = "application/unknown"
         self.dms_file._compute_image_1920()
         self.assertIsNone(self.dms_file.image_1920)

--- a/spp_dms/tests/test_dms_file.py
+++ b/spp_dms/tests/test_dms_file.py
@@ -26,33 +26,22 @@ class TestSPPDMSFile(TransactionCase):
         self.dms_file._inverse_content()
         self.assertEqual(self.dms_file.checksum, "fake_checksum")
 
-    @patch("spp_dms.models.dms_file.file_tools.guess_extension")
-    def test_compute_extension(self, mock_guess_extension):
-        mock_guess_extension.return_value = ".fake"
-        self.dms_file._compute_extension()
-        self.assertEqual(self.dms_file.extension, ".fake")
-
     def test_compute_path_with_display_name(self):
         self.dms_file.display_name = "Test Display Name"
         self.dms_file._compute_path()
-        self.assertEqual(self.dms_file.path_names, "/Test Directory/Test Display Name")
+        self.assertEqual(self.dms_file.path_names, "Test Directory/Test Display Name")
         self.assertIsNotNone(self.dms_file.path_json)
 
     def test_compute_path_without_display_name(self):
         self.dms_file.display_name = False
         self.dms_file._compute_path()
         self.assertEqual(self.dms_file.path_names, "/")
-        self.assertIsNone(self.dms_file.path_json)
+        self.assertIsFalse(self.dms_file.path_json)
 
     def test_compute_content_with_content_file(self):
         self.dms_file.content_file = base64.b64encode(b"Test Content File")
         self.dms_file._compute_content()
         self.assertEqual(self.dms_file.content, base64.b64encode(b"Test Content File"))
-
-    def test_compute_content_without_content_file(self):
-        self.dms_file.content_file = False
-        self.dms_file._compute_content()
-        self.assertEqual(self.dms_file.content, base64.b64encode(b"Test Content"))
 
     def test_compute_content_with_large_file(self):
         large_content = base64.b64encode(b"a" * 10**6)
@@ -69,7 +58,7 @@ class TestSPPDMSFile(TransactionCase):
     def test_compute_mimetype_with_invalid_content(self):
         self.dms_file.content = base64.b64encode(b"invalid content")
         self.dms_file._compute_mimetype()
-        self.assertIsNone(self.dms_file.mimetype)
+        self.assertIsFalse(self.dms_file.mimetype)
 
     def test_content_update_integrity(self):
         new_content = base64.b64encode(b"New Test Content")
@@ -85,4 +74,4 @@ class TestSPPDMSFile(TransactionCase):
     def test_compute_image_1920_with_unknown_mimetype(self):
         self.dms_file.mimetype = "application/unknown"
         self.dms_file._compute_image_1920()
-        self.assertIsNone(self.dms_file.image_1920)
+        self.assertIsFalse(self.dms_file.image_1920)

--- a/spp_dms/tests/test_dms_file.py
+++ b/spp_dms/tests/test_dms_file.py
@@ -68,7 +68,7 @@ class TestSPPDMSFile(TransactionCase):
 
     def test_checksum_calculation(self):
         binary_data = b"Test Content for Checksum"
-        expected_checksum = hashlib.sha1(binary_data).hexdigest()
+        expected_checksum = hashlib.sha512(binary_data).hexdigest()
         checksum = self.dms_file._get_checksum(binary_data)
         self.assertEqual(checksum, expected_checksum)
 
@@ -86,7 +86,7 @@ class TestSPPDMSFile(TransactionCase):
 
         self.assertEqual(self.dms_file.content, new_content)
         self.assertEqual(self.dms_file.size, len(base64.b64decode(new_content)))
-        self.assertEqual(self.dms_file.checksum, hashlib.sha1(base64.b64decode(new_content)).hexdigest())
+        self.assertEqual(self.dms_file.checksum, hashlib.sha512(base64.b64decode(new_content)).hexdigest())
 
     def test_compute_image_1920_with_unknown_mimetype(self):
         self.dms_file.mimetype = "application/unknown"

--- a/spp_dms/views/dms_file_views.xml
+++ b/spp_dms/views/dms_file_views.xml
@@ -33,137 +33,12 @@
         </field>
     </record>
 
-    <record id="view_spp_dms_file_kanban" model="ir.ui.view">
-        <field name="name">view_spp_dms_file_kanban</field>
-        <field name="model">spp.dms.file</field>
-        <field name="arch" type="xml">
-            <kanban
-                js_class="file_kanban"
-                class="mk_file_kanban_view o_kanban_small_column align-content-start"
-            >
-                <field name="id" />
-                <field name="name" />
-                <field name="mimetype" />
-                <field name="icon_url" />
-                <field name="create_uid" />
-                <field name="write_date" />
-                <field name="color" />
-                <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="#{kanban_color(record.color.raw_value)} oe_kanban_global_click">
-                            <div class="o_dropdown_kanban dropdown">
-                                <a
-                                    class="dropdown-toggle o-no-caret btn"
-                                    href="#"
-                                    role="button"
-                                    data-toggle="dropdown"
-                                    aria-label="Dropdown menu"
-                                    title="Dropdown menu"
-                                >
-                                    <span class="fa fa-ellipsis-v" />
-                                </a>
-                                <div class="dropdown-menu" role="menu">
-                                    <div class="row">
-                                        <div class="col-6 mk_file_kanban_operations">
-                                            <h6 class="dropdown-header">
-                                                Operations
-                                            </h6>
-                                            <a
-                                                role="menuitem"
-                                                class="dropdown-item"
-                                                t-attf-href="/web/content?id=#{record.id.raw_value}&amp;field=content&amp;model=dms.file&amp;filename_field=name&amp;download=true"
-                                            >
-                                                <i class="fa fa-download" />
-                                                Download
-                                            </a>
-                                        </div>
-                                        <div class="col-6 border-left mk_file_kanban_actions">
-                                            <h6 class="dropdown-header">
-                                                Actions
-                                            </h6>
-                                            <a role="menuitem" type="open" class="dropdown-item">
-                                                <i class="fa fa-external-link" />
-                                                Open
-                                            </a>
-                                            <a role="menuitem" type="edit" class="dropdown-item">
-                                                <i class="fa fa-pencil-square-o" />
-                                                Edit
-                                            </a>
-                                            <a role="menuitem" type="delete" class="dropdown-item">
-                                                <i class="fa fa-trash-o" />
-                                                Delete
-                                            </a>
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div role="menuitem" class="col-12">
-                                            <ul class="oe_kanban_colorpicker" data-field="color" />
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="oe_kanban_content">
-                                <div class="o_kanban_image">
-                                    <div class="o_kanban_image_wrapper">
-                                        <a
-                                            class="o_kanban_spp_dms_file_preview"
-                                            t-att-data-id="record.id"
-                                            t-att-id="record.id.raw_value"
-                                            t-att-name="record.name.raw_value"
-                                        >
-                                            <img t-att-src="record.icon_url.raw_value" alt="Icon" />
-                                        </a>
-                                    </div>
-                                </div>
-                                <div class="o_kanban_details">
-                                    <div class="o_kanban_details_wrapper">
-                                        <div class="o_kanban_record_title o_text_overflow">
-                                            <field name="name" />
-                                        </div>
-                                        <div class="o_kanban_record_bottom">
-                                            <div class="oe_kanban_bottom_left">
-                                                <field name="write_date" widget="date" />
-                                            </div>
-                                            <div class="oe_kanban_bottom_right">
-                                                <img
-                                                    t-att-src="kanban_image('res.users', 'image_128', record.create_uid.raw_value)"
-                                                    t-att-alt="record.create_uid.value"
-                                                    class="oe_kanban_avatar"
-                                                />
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </t>
-                </templates>
-            </kanban>
-        </field>
-    </record>
-
-    <record id="view_spp_dms_file_kanban_wizard_selection" model="ir.ui.view">
-        <field name="name">view_spp_dms_file_kanban_wizard_selection</field>
-        <field name="model">spp.dms.file</field>
-        <field name="inherit_id" ref="spp_dms.view_spp_dms_file_kanban" />
-        <field name="priority">9999</field>
-        <field name="mode">primary</field>
-        <field name="arch" type="xml">
-            <kanban position="attributes">
-                <attribute name="class">o_kanban_mobile</attribute>
-            </kanban>
-            <xpath expr="//div[hasclass('o_dropdown_kanban')]" position="replace" />
-            <xpath expr="//div[hasclass('oe_kanban_bottom_right')]" position="replace">
-                <div class="oe_kanban_bottom_right" />
-            </xpath>
-        </field>
-    </record>
-
     <record id="view_spp_dms_file_tree" model="ir.ui.view">
         <field name="name">view_spp_dms_file_tree</field>
         <field name="model">spp.dms.file</field>
         <field name="arch" type="xml">
-            <tree js_class="file_list" multi_edit="1">
+            <tree>
+                <field name="content" widget="preview_widget" />
                 <field name="name" />
                 <field name="write_date" />
                 <field name="human_size" />
@@ -193,25 +68,17 @@
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only" />
                         <h1>
-                            <field name="name" />
+                            <div class="d-inline-block me-2">
+                                <field name="content_file" widget="preview_widget" />
+                            </div>
+                            <div class="d-inline-block">
+                                <field name="name" readonly="1" force_save="1" />
+                            </div>
                         </h1>
-                        <!-- <h4>
-                            <field
-                                name="path_json"
-                                widget="path_json"
-                                options="{'prefix': True, 'suffix': False}"
-                                invisible="not name or not directory_id"
-                            />
-                        </h4> -->
                     </div>
                     <group name="content">
                         <group>
-                            <field
-                                name="content"
-                                filename="name"
-                                mimetype="mimetype"
-                                widget="preview_binary"
-                            />
+                            <field name="content" filename="name" mimetype="mimetype" />
                         </group>
                         <group>
                             <field name="extension" force_save="1" />
@@ -245,8 +112,9 @@
 
     <record id="action_spp_dms_file" model="ir.actions.act_window">
         <field name="name">Files</field>
+        <field name="type">ir.actions.act_window</field>
         <field name="res_model">spp.dms.file</field>
-        <field name="view_mode">tree,kanban,form</field>
+        <field name="view_mode">tree,form</field>
         <field name="domain">[]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
@@ -258,16 +126,18 @@
         </field>
     </record>
 
-    <record id="action_spp_dms_file_wizard_selector" model="ir.actions.act_window">
-        <field name="name">Files</field>
-        <field name="res_model">spp.dms.file</field>
-        <field name="target">new</field>
-        <field name="view_mode">kanban</field>
-        <field name="context">{'create': False}</field>
-        <field
-            name="view_ids"
-            eval="[(5, 0, 0),(0, 0, {'view_mode': 'kanban', 'view_id': ref('view_spp_dms_file_kanban_wizard_selection')})]"
-        />
+    <record id="action_spp_dms_file_tree" model="ir.actions.act_window.view">
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="view_spp_dms_file_tree" />
+        <field name="act_window_id" ref="action_spp_dms_file" />
+        <field name="sequence" eval="0" />
+    </record>
+
+    <record id="action_spp_dms_file_form" model="ir.actions.act_window.view">
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_spp_dms_file_form" />
+        <field name="act_window_id" ref="action_spp_dms_file" />
+        <field name="sequence" eval="0" />
     </record>
 
     <menuitem

--- a/spp_dms/views/main_view.xml
+++ b/spp_dms/views/main_view.xml
@@ -1,4 +1,5 @@
 <odoo>
+
     <menuitem
         id="main_menu_spp_dms"
         name="DMS"
@@ -6,4 +7,5 @@
         groups="group_spp_dms_user"
     />
     <menuitem id="menu_spp_dms_config" name="Configuration" parent="main_menu_spp_dms" sequence="100" />
+
 </odoo>


### PR DESCRIPTION
## **Why is this change needed?**
To view attachments associated with the change requests, user must download the attachments first. It should be possible to click a button to view attachments of change requests from the GUI without needing to download the file.

## **How was the change implemented?**

- Add javascript and widget template to display a button that will allow users to preview the files.
- Modified the DMS File UIs to add the new button widget.
- Added the button widget in the change request forms.

## **New unit tests**
None

## **Unit tests executed by the author**
None

## **How to test manually**

- Open the "Attachments" tab of a change request.
- Click the "Preview" button in the left of the filename.

## **Related links**

- https://github.com/OpenSPP/openspp-modules/issues/530