### PR TITLE
Fix issue with test case: VCIIssuer.test_issue_vc_qr

### DIFF
--- a/spp_openid_vci/tests/test_vci_issuer.py
+++ b/spp_openid_vci/tests/test_vci_issuer.py
@@ -147,7 +147,7 @@ class VCIIssuer(TransactionCase):
 
         self.assertIsNotNone(vc_qr)
         self.assertIsInstance(vc_qr, dict)
-        self.assertEqual(vc_qr.get("type"), "ir.actions.act_window")
+        self.assertEqual(vc_qr.get("type"), "ir.actions.report")
 
     def test_sign_and_issue_credential(self):
         credential_data = {


### PR DESCRIPTION
## **Why is this change needed?**
An error is generated when running the "VCIIssuer.test_issue_vc_qr" test. Here's the error details
- AssertionError: 'ir.actions.report' != 'ir.actions.act_window'

## **How was the change implemented?**

- Change "ir.actions.act_window" to "ir.actions.report" in line 150: self.assertEqual(vc_qr.get("type"), "ir.actions.report")
- The change is needed because vc_qr returns a report instead of a window action.

## **New unit tests**
None

## **Unit tests executed by the author**
VCIIssuer.test_issue_vc_qr

## **How to test manually**

- When commits are added to PR's the test will automatically run.
- Check the "tests (PyPI) / test with Odoo 17/Ubuntu 22.04 (pull_request)" from the github checks.

## **Related links**

