### PR TITLE
Temporarily disabling the execution Pypi-based CI

### DIFF
--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -2,9 +2,6 @@ name: tests (PyPI)
 # fetching the OpenG2P dependencies from OpenSPP PyPI, locked to the version of the OpenSPP 17.0.1.2 (batanes) release
 
 on:
-  pull_request:
-    branches:
-      - "17.0*"
   push:
     branches:
       - "17.0"


### PR DESCRIPTION
## **Why is this change needed?**
We are in the process of updating the OpenSPP PyPI packages, and right now, the result of the PyPI-based CI is not reliable and uses unnecessary time and resources.
