### PR TITLE
Improved farmer registry base write function

### DIFF
--- a/spp_farmer_registry_base/models/farm.py
+++ b/spp_farmer_registry_base/models/farm.py
@@ -19,6 +19,8 @@ class Farm(models.Model):
         "spp.farmer": "farmer_id",
     }
 
+    CREATE_OR_UPDATE_FARMER = True
+
     coordinates = fields.GeoPointField(string="GPS Coordinates")
     farm_asset_ids = fields.One2many("spp.farm.asset", "asset_farm_id", string="Farm Assets")
     farm_machinery_ids = fields.One2many("spp.farm.asset", "machinery_farm_id", string="Farm Machinery")
@@ -110,6 +112,9 @@ class Farm(models.Model):
     @api.model
     def write(self, vals):
         farm = super().write(vals)
+        if not self.CREATE_OR_UPDATE_FARMER:
+            return farm
+
         for rec in self:
             if rec.is_group and rec.kind.id == self.env.ref("spp_farmer_registry_base.kind_farm").id:
                 head_member = rec.get_group_head_member()

--- a/spp_farmer_registry_base/models/farm.py
+++ b/spp_farmer_registry_base/models/farm.py
@@ -19,8 +19,6 @@ class Farm(models.Model):
         "spp.farmer": "farmer_id",
     }
 
-    CREATE_OR_UPDATE_FARMER = True
-
     coordinates = fields.GeoPointField(string="GPS Coordinates")
     farm_asset_ids = fields.One2many("spp.farm.asset", "asset_farm_id", string="Farm Assets")
     farm_machinery_ids = fields.One2many("spp.farm.asset", "machinery_farm_id", string="Farm Machinery")
@@ -112,9 +110,12 @@ class Farm(models.Model):
     @api.model
     def write(self, vals):
         farm = super().write(vals)
-        if not self.CREATE_OR_UPDATE_FARMER:
-            return farm
 
+        self._create_update_farmer()
+
+        return farm
+
+    def _create_update_farmer(self):
         for rec in self:
             if rec.is_group and rec.kind.id == self.env.ref("spp_farmer_registry_base.kind_farm").id:
                 head_member = rec.get_group_head_member()
@@ -127,8 +128,6 @@ class Farm(models.Model):
                 rec.create_update_farmer(rec)
             elif not rec.is_group and rec.is_registrant:
                 rec.update_farmer(rec)
-
-        return farm
 
     def _process_record_to_feature(self, record, transformer):
         """


### PR DESCRIPTION
## **Why is this change needed?**

Improved the write function to be able to allow not to automatically create a farmer when creating 

## **How was the change implemented?**

Added a class-scope variable named CREATE_OR_UPDATE_FARMER

## **New unit tests**

None

## **Unit tests executed by the author**

None

## **How to test manually**

- Install OpenSPP Farmer Registry Demo module
- Check if the farmer demo data generator is working
- Update one farm, any fields will do
- Check if there will be no error 

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/599
