### PR TITLE
Bump version to 17.0.1.3.0

### DIFF
--- a/g2p_connect_demo/__manifest__.py
+++ b/g2p_connect_demo/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "G2P Connect Demo",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_api/__manifest__.py
+++ b/spp_api/__manifest__.py
@@ -7,7 +7,7 @@
     "images": [
         "images/icon.png",
     ],
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "application": False,
     "author": "OpenSPP.org",
     "development_status": "Production/Stable",

--- a/spp_api_records/__manifest__.py
+++ b/spp_api_records/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "OpenSPP API Records",
     "summary": """Provides RESTful API endpoints for accessing and managing OpenSPP's core data, including service points, programs, products, and entitlements.""",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "author": "OpenSPP.org",
     "development_status": "Beta",
     "maintainers": ["jeremi", "gonzalesedwin1123", "reichie020212"],

--- a/spp_area/__manifest__.py
+++ b/spp_area/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "OpenSPP Area Management",
     "summary": "This module enables management of geographical areas, linking them to registrants for targeted interventions and analysis in social protection programs.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_area_gis/__manifest__.py
+++ b/spp_area_gis/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "OpenSPP Area GIS",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_audit_config/__manifest__.py
+++ b/spp_audit_config/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "OpenSPP Audit Config",
     "summary": "This module allows administrators to define and manage audit rules to track and log changes made to critical data within the OpenSPP platform, ensuring data security and integrity.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_audit_log/__manifest__.py
+++ b/spp_audit_log/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "SPP Audit Log",
     "summary": "Provides audit logging functionality to track data changes and user actions within OpenSPP, enhancing transparency and accountability.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_audit_post/__manifest__.py
+++ b/spp_audit_post/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "G2P Registry: Audit Post",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_auto_update_entitlements/__manifest__.py
+++ b/spp_auto_update_entitlements/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Auto-Update Entitlements",
     "summary": "Automatically updates entitlement states based on their redemption status at the end of program cycles in OpenSPP.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_base/__manifest__.py
+++ b/spp_base/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "OpenSPP Base",
     "category": "OpenSPP/OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_base_api/__manifest__.py
+++ b/spp_base_api/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "OpenSPP Base API",
     "summary": """Provides foundational API functions and methods for seamless interaction with the OpenSPP system, enabling data exchange via APIs or XML-RPC.""",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "application": False,
     "author": "OpenSPP.org",
     "development_status": "Production/Stable",

--- a/spp_base_demo/__manifest__.py
+++ b/spp_base_demo/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Base Demo",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_base_gis/__manifest__.py
+++ b/spp_base_gis/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP Base GIS",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_base_gis_demo/__manifest__.py
+++ b/spp_base_gis_demo/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Base GIS Demo",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",
     "license": "LGPL-3",

--- a/spp_base_gis_rest/__manifest__.py
+++ b/spp_base_gis_rest/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Base GIS REST",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_base_setting/__manifest__.py
+++ b/spp_base_setting/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Base Settings",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_basic_cash_entitlement_spent/__manifest__.py
+++ b/spp_basic_cash_entitlement_spent/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Program Entitlement Basic Cash Spent",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_change_request/__manifest__.py
+++ b/spp_change_request/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Change Request",
     "summary": "Streamlines the process of handling changes to registrant information within the OpenSPP system, providing a structured framework for submitting, reviewing, approving, and applying modifications.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_change_request_add_children_demo/__manifest__.py
+++ b/spp_change_request_add_children_demo/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "OpenSPP Change Request Demo: Add Child/Member",
     "summary": "Provides a demonstration of adding children or members to an existing group in the registry using the OpenSPP Change Request framework, including a dedicated form, ID scanning integration, and automated data updates.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_change_request_add_farmer/__manifest__.py
+++ b/spp_change_request_add_farmer/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "OpenSPP Change Request: Add Farmer",
     "summary": "Provides a specialized workflow for adding new farmers to existing groups in the registry.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_change_request_change_info/__manifest__.py
+++ b/spp_change_request_change_info/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "Change Information Change Request",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_consent/__manifest__.py
+++ b/spp_consent/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Consent",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_custom_field/__manifest__.py
+++ b/spp_custom_field/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Custom Fields",
     "summary": "Adds customizable fields to registrant profiles for enhanced data collection and program management in OpenSPP.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_custom_field_custom_filter/__manifest__.py
+++ b/spp_custom_field_custom_filter/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "OpenSPP Custom Field Custom Filter Integration",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",
     "license": "LGPL-3",

--- a/spp_custom_field_recompute_daily/__manifest__.py
+++ b/spp_custom_field_recompute_daily/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Custom Field Recompute Daily",
     "summary": "Enables daily recomputation of specified fields to maintain data accuracy and improve performance by offloading intensive calculations.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_custom_fields_ui/__manifest__.py
+++ b/spp_custom_fields_ui/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP Custom Fields UI",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_custom_filter/__manifest__.py
+++ b/spp_custom_filter/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP Custom Filter",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "summary": "Enhances Odoo's filtering system by allowing administrators to control which fields are displayed in filter dropdowns, improving user experience and data management.",
     "author": "OpenSPP.org",
     "maintainers": ["nhatnm0612"],

--- a/spp_custom_filter_ui/__manifest__.py
+++ b/spp_custom_filter_ui/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP Custom Filter UI",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "summary": "Customizes the OpenSPP UI to enhance filtering for Res Partners, improving usability and efficiency in managing registrants within social protection programs.",
     "author": "OpenSPP.org",
     "maintainers": ["nhatnm0612"],

--- a/spp_data_export/__manifest__.py
+++ b/spp_data_export/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP Data Export",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_dci_api_server/__manifest__.py
+++ b/spp_dci_api_server/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "OpenSPP DCI API Server",
     "summary": "Provides a DCI-compliant RESTful API for secure data exchange with OpenSPP's registry.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "author": "OpenSPP.org",
     "development_status": "Beta",
     "maintainers": [

--- a/spp_demo/__manifest__.py
+++ b/spp_demo/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Demo",
     "summary": "Provides demonstration data and functionalities for the OpenSPP system, showcasing its capabilities in managing social protection programs and registries with pre-populated data for exploration and testing.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_dms/__manifest__.py
+++ b/spp_dms/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "OpenSPP Document Management System",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_eligibility_sql/__manifest__.py
+++ b/spp_eligibility_sql/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP SQL Query Eligibility Manager",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_eligibility_tags/__manifest__.py
+++ b/spp_eligibility_tags/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Tag Based Eligibility Manager",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_encryption/__manifest__.py
+++ b/spp_encryption/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP Encryption Module",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_ent_trans/__manifest__.py
+++ b/spp_ent_trans/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Entitlement Transactions",
     "summary": "This module records and manages transactions related to entitlement redemptions, providing a transparent history for both cash and in-kind benefits.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_entitlement_basket/__manifest__.py
+++ b/spp_entitlement_basket/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP Entitlement Basket",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_entitlement_cash/__manifest__.py
+++ b/spp_entitlement_cash/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Cash Entitlement",
     "summary": "Manage cash-based entitlements for beneficiaries within social protection programs, including defining calculation rules, automating disbursement, and tracking payments.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_entitlement_in_kind/__manifest__.py
+++ b/spp_entitlement_in_kind/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP In-Kind Entitlement",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_ethnic_group/__manifest__.py
+++ b/spp_ethnic_group/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "OpenSPP: Ethnic Group",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_event_data/__manifest__.py
+++ b/spp_event_data/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "OpenSPP Event Data",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_event_data_program_membership/__manifest__.py
+++ b/spp_event_data_program_membership/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "OpenSPP Event Data Program Membership",
     "summary": "This module allows users to record and track program membership-related events, such as enrollment, suspension, or exit, and link them to specific program membership records within OpenSPP.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_event_demo/__manifest__.py
+++ b/spp_event_demo/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "OpenSPP Event Demo",
     "summary": "Provides demonstration data and functionalities for the OpenSPP event tracking system, showcasing practical applications through predefined event types, data models, views, and wizards.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_exclusion_filter/__manifest__.py
+++ b/spp_exclusion_filter/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Exclusion Filter",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_farmer_registry_base/__manifest__.py
+++ b/spp_farmer_registry_base/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "OpenSPP Farmer Registry Base",
     "summary": "Base module for managing farmer registries, linking farmers to farms, land, and agricultural activities.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_farmer_registry_dashboard/__manifest__.py
+++ b/spp_farmer_registry_dashboard/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "OpenSPP Farmer Registry Dashboard",
     "summary": "Provides interactive dashboards and reports for visualizing data from the OpenSPP Farmer Registry, offering insights into key metrics and trends related to registered farmers.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_farmer_registry_demo/__manifest__.py
+++ b/spp_farmer_registry_demo/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "OpenSPP Farmer Registry Demo",
     "summary": "Provides pre-populated demo data for the OpenSPP Farmer Registry, showcasing its features with realistic sample data.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_idpass/__manifest__.py
+++ b/spp_idpass/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "ID PASS",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_idqueue/__manifest__.py
+++ b/spp_idqueue/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP ID Queue",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_import_dci_api/__manifest__.py
+++ b/spp_import_dci_api/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "OpenSPP Import: DCI API",
     "summary": "Enables integration with external registries, particularly those adhering to the DCI (Digital Civil Identity) standard, for importing and synchronizing registrant data into OpenSPP.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "author": "OpenSPP.org",
     "development_status": "Beta",
     "maintainers": ["jeremi", "gonzalesedwin1123", "reichie020212"],

--- a/spp_import_match/__manifest__.py
+++ b/spp_import_match/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "OpenSPP Import Match",
     "summary": "Enhances data imports in OpenSPP by enabling the matching of imported records with existing data to prevent duplicates and ensure data integrity.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_irrigation/__manifest__.py
+++ b/spp_irrigation/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "OpenSPP Irrigation",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_land_record/__manifest__.py
+++ b/spp_land_record/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "OpenSPP Land Record",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_manual_eligibility/__manifest__.py
+++ b/spp_manual_eligibility/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "SPP Program: Manual Eligibility",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_manual_entitlement/__manifest__.py
+++ b/spp_manual_entitlement/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Manual Entitlement",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_oauth/__manifest__.py
+++ b/spp_oauth/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "OpenSPP API: Oauth",
     "summary": "Provides OAuth 2.0 authentication for secure access to the OpenSPP API.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "author": "OpenSPP.org",
     "development_status": "Production/Stable",
     "maintainers": ["jeremi", "gonzalesedwin1123", "reichie020212"],

--- a/spp_openid_vci/__manifest__.py
+++ b/spp_openid_vci/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP OpenID VCI",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_openid_vci_group/__manifest__.py
+++ b/spp_openid_vci_group/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "OpenSPP OpenID VCI Group",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_openid_vci_individual/__manifest__.py
+++ b/spp_openid_vci_individual/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP OpenID VCI Individual",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_pmt/__manifest__.py
+++ b/spp_pmt/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "OpenSPP Proxy Means Testing",
     "summary": "Calculates a Proxy Means Testing (PMT) score for groups of registrants to aid in beneficiary identification and prioritization for social protection programs.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_pos/__manifest__.py
+++ b/spp_pos/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP POS",
     "summary": "Extend Odoo POS to redeem entitlements from OpenSPP for secure and efficient beneficiary transactions.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_program_id/__manifest__.py
+++ b/spp_program_id/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Program ID",
     "summary": "Generates and manages unique IDs for social protection programs, enhancing identification and integration within the OpenSPP platform.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_programs/__manifest__.py
+++ b/spp_programs/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Programs",
     "summary": "Manage cash and in-kind entitlements, integrate with inventory, and enhance program management features for comprehensive social protection and agricultural support.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_programs_compliance_criteria/__manifest__.py
+++ b/spp_programs_compliance_criteria/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Programs: Compliance Criteria",
     "summary": "Manages compliance criteria within social protection programs, allowing administrators to define and enforce additional eligibility requirements beyond initial program criteria.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_programs_sp/__manifest__.py
+++ b/spp_programs_sp/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP Programs: Service Points Integration",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_registrant_import/__manifest__.py
+++ b/spp_registrant_import/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Registrant Import",
     "summary": "Streamlines the import of registrant data into OpenSPP, simplifies data mapping, and automates unique ID generation.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_registrant_tag/__manifest__.py
+++ b/spp_registrant_tag/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Registrant Tags",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_registry_data_source/__manifest__.py
+++ b/spp_registry_data_source/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "OpenSPP Data Source",
     "summary": "Provides a framework for integrating external data sources into OpenSPP, enabling connection to and retrieval of data from external systems like farmer registries and social protection programs.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_registry_group_hierarchy/__manifest__.py
+++ b/spp_registry_group_hierarchy/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "OpenSPP Registry Group Hierarchy",
     "summary": "Introduces hierarchical relationships between groups, allowing for nested group structures within social protection programs and farmer registries.",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_scan_id_document/__manifest__.py
+++ b/spp_scan_id_document/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Registry: Scan ID Document",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_service_point_device/__manifest__.py
+++ b/spp_service_point_device/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Service Point Device",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_service_points/__manifest__.py
+++ b/spp_service_points/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "OpenSPP Service Points Management",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": "1",
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/spp_starter/__manifest__.py
+++ b/spp_starter/__manifest__.py
@@ -3,7 +3,7 @@
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "license": "LGPL-3",
     "development_status": "Beta",
     "maintainers": ["jeremi", "gonzalesedwin1123"],

--- a/spp_user_roles/__manifest__.py
+++ b/spp_user_roles/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP User Roles",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",

--- a/theme_openspp_muk/__manifest__.py
+++ b/theme_openspp_muk/__manifest__.py
@@ -3,7 +3,7 @@
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",
     "category": "OpenSPP",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "depends": [
         "base",
         "calendar",


### PR DESCRIPTION
## **Why is this change needed?**
As Batanes Refresh (17.0.1.2.1) has been released, we want to target the next release, which is 17.0.1.3.x.