### PR TITLE
Fixed issue where OpenG2P-program requirements were overwriting the branch

### DIFF
--- a/.github/workflows/test-legacy.yml
+++ b/.github/workflows/test-legacy.yml
@@ -88,7 +88,11 @@ jobs:
           cp -r openg2p-registry/* ${ADDONS_DIR}/
           cat test-requirements.txt >> spp-test-requirements.txt
           cp -r openg2p-program/* ${ADDONS_DIR}/
-          cat test-requirements.txt >> spp-test-requirements.txt
+          # ----------------------------------------------------------------------------
+          # Do not add test-requirements.txt to spp-test-requirements.txt as those requirements overwrite the
+          # openspp-modules branch we are building
+          # cat test-requirements.txt >> spp-test-requirements.txt
+          # ----------------------------------------------------------------------------
           cp -r openg2p-security/* ${ADDONS_DIR}/
           cat test-requirements.txt >> spp-test-requirements.txt
           cp -r openg2p-vci/* ${ADDONS_DIR}/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,9 +125,11 @@ jobs:
           cp -r openg2p-registry/* ${ADDONS_DIR}/
           cat test-requirements.txt >> spp-test-requirements.txt
           cp -r openg2p-program/* ${ADDONS_DIR}/
-          cat test-requirements.txt >> spp-test-requirements.txt
-          # cp -r openg2p-storage/* ${ADDONS_DIR}/
+          # ----------------------------------------------------------------------------
+          # Do not add test-requirements.txt to spp-test-requirements.txt as those requirements overwrite the
+          # openspp-modules branch we are building
           # cat test-requirements.txt >> spp-test-requirements.txt
+          # ----------------------------------------------------------------------------
           # MUK Addons
           cp -r mukit-modules/* ${ADDONS_DIR}/
       - name: Add g2p-programs and odoo-test-helper to spp-test-requirements.txt


### PR DESCRIPTION
## **Why is this change needed?**
It is key to ensure the expected code is being built and tested.
As it was, five OpenSPP addons would always use the `17.0` branch version instead of the version contained in the branch being built.

## **How was the change implemented?**
The inclusion of the requirements from OpenG2P Program are no longer installed, as they were all requirements on OpenSPP addons.

## **New unit tests**
N/A

## **Unit tests executed by the author**
Full test suite.

## **How to test manually**
N/A

## **Related links**
https://github.com/OpenSPP/openg2p-program/commit/e360ba920dbff318ab372e83144d803f744621e0