### PR TITLE
Improvements of farmer demo generator

### DIFF
--- a/spp_farmer_registry_demo/models/generate_farmer_data.py
+++ b/spp_farmer_registry_demo/models/generate_farmer_data.py
@@ -80,7 +80,7 @@ class SPPGenerateFarmerData(models.Model):
             # self._generate_sample_data(res=self)
 
         main_job = group(*jobs)
-        main_job.on_done(self.delayable(channel="root.laos_data_generator")._mark_done())
+        main_job.on_done(self.delayable()._mark_done())
         main_job.delay()
 
     def _mark_done(self):

--- a/spp_farmer_registry_demo/views/generate_farmer_data_view.xml
+++ b/spp_farmer_registry_demo/views/generate_farmer_data_view.xml
@@ -24,8 +24,25 @@
                 <header>
                     <field name="state" widget="statusbar" statusbar_visible="draft,generate" />
                 </header>
+                <field name="locked" invisible="True" />
+                <div
+                    class="alert alert-warning text-center o_form_header"
+                    role="status"
+                    invisible="not locked"
+                >
+                    <span>Warning: Operation in progress: </span>
+                    <field name="locked_reason" class="o_stat_value" />
+                    <button
+                        name="refresh_page"
+                        type="object"
+                        class="btn_warning"
+                        icon="fa-refresh"
+                        title="Refresh Page"
+                        string="Refresh"
+                    />
+                </div>
                 <sheet>
-                    <div class="oe_button_box" name="button_box">
+                    <div class="oe_button_box" name="button_box" invisible="locked">
                         <button
                             type="object"
                             class="oe_stat_button"


### PR DESCRIPTION
## **Why is this change needed?**

laos farmer data generator needs to accomodate generating 1000 data or more.

## **How was the change implemented?**

Improve the generation of data

## **New unit tests**

None

## **Unit tests executed by the author**

None

## **How to test manually**

- Install `OpenSPP Farmer Registry Demo` module
- Go to Registry -> Configuration -> Generate Sample Farmer Data

Test 1.
- Go back to Generate Sample Farmer Data.
- Create a records with atleast 1000 number of farmer groups.
- Click Generate Sample Data button.
- Wait for the state to change to `Generated`. Warning: This will take a lot of time so while waiting, you can brew a coffee or play games.
- Check if they are successfully created.

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/599
