### PR TITLE
raise error when found multiple match

### DIFF
--- a/spp_import_match/models/import_match.py
+++ b/spp_import_match/models/import_match.py
@@ -66,10 +66,11 @@ class SPPImportMatch(models.Model):
                         domain.append((field_value, "=", row_value))
             if not combination_valid:
                 continue
-            _logger.info("DOMAIN: %s" % domain)
             match = model.search(domain)
             if len(match) == 1:
                 return match
+            elif len(match) > 1:
+                raise ValidationError(_(f"Multiple matches found for '{match[0].name}'!"))
 
         return model
 

--- a/spp_import_match/models/import_match.py
+++ b/spp_import_match/models/import_match.py
@@ -70,7 +70,7 @@ class SPPImportMatch(models.Model):
             if len(match) == 1:
                 return match
             elif len(match) > 1:
-                raise ValidationError(_(f"Multiple matches found for '{match[0].name}'!"))
+                raise ValidationError(_("Multiple matches found for '%s'!" % match[0].name))
 
         return model
 

--- a/spp_import_match/views/import_match_view.xml
+++ b/spp_import_match/views/import_match_view.xml
@@ -39,15 +39,15 @@
                                 <field name="field_ids">
                                     <tree editable="bottom">
                                         <field name="field_id" options="{'no_create': True}" />
-                                        <field name="relation" invisible="1" />
+                                        <field name="relation" column_invisible="1" />
                                         <field
                                             name="sub_field_id"
                                             attrs="{'readonly': [('relation', '=', False)], 'required': [('relation', '!=', False)]}"
                                             domain="[('model_id.model', '=', relation)]"
                                             options="{'no_create': True}"
                                         />
-                                        <field name="match_id" invisible="1" />
-                                        <field name="model_id" invisible="1" />
+                                        <field name="match_id" column_invisible="1" />
+                                        <field name="model_id" column_invisible="1" />
                                         <field name="conditional" />
                                         <field
                                             name="imported_value"


### PR DESCRIPTION
## **Why is this change needed?**
To raise an error if import match found multiple matches.

## **How was the change implemented?**
Added a condition to check if matches found is greater that 1, then raise an error.

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
- Install or Upgrade `spp_import_match`
- Create an import match configuration for Contact (Registry > Configuration > Import Match)
- Check overwrite match, and Add `name` in Fields.
- Try importing with at least 2 existing duplicated name in Groups or Individuals.
- If error was raised this PR is done.

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/573
