### PR TITLE
restrict deletion of species if already assigned to a record

### DIFF
--- a/spp_farmer_registry_base/models/agricultural_activity.py
+++ b/spp_farmer_registry_base/models/agricultural_activity.py
@@ -31,7 +31,9 @@ class AgriculturalActivity(models.Model):
         ],
     )
 
-    species_id = fields.Many2one("spp.farm.species", string="Species", domain="[('species_type', '=', activity_type)]")
+    species_id = fields.Many2one(
+        "spp.farm.species", ondelete="restrict", string="Species", domain="[('species_type', '=', activity_type)]"
+    )
 
     @api.onchange("crop_farm_id")
     def _onchange_farm_id(self):


### PR DESCRIPTION
## **Why is this change needed?**
To raise an error if deleting an already assigned species.

## **How was the change implemented?**
Added the `ondelete="restrict"` on species_id.

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
- Install or Upgrade `spp_farmer_registry_base`.
- Find a species which is already assigned to a Group.
- Go to Configuration > Species.
- Try to delete that species.
- A Validation error should be raised.

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/594
