### PR TITLE
add button to show all cycle members

### DIFF
--- a/spp_programs/views/cycle_view.xml
+++ b/spp_programs/views/cycle_view.xml
@@ -28,12 +28,13 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
             </xpath>
             <xpath expr="//button[@name='open_entitlements_form']" position="attributes">
                 <attribute name="invisible">entitlements_count == 0</attribute>
+                <attribute name="icon">fa-calculator</attribute>
             </xpath>
             <xpath expr="//button[@name='open_entitlements_form']" position="after">
                 <button
                     type="object"
                     class="oe_stat_button"
-                    icon="fa-folder-open-o"
+                    icon="fa-calculator"
                     name="open_entitlements_form"
                     invisible="inkind_entitlements_count == 0"
                 >
@@ -56,6 +57,10 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                     string="To Approve"
                     invisible="state != 'draft' or inkind_entitlements_count == 0"
                 />
+            </xpath>
+
+            <xpath expr="//button[@name='open_payments_form']" position="attributes">
+                <attribute name="icon">fa-file-text-o</attribute>
             </xpath>
         </field>
     </record>

--- a/spp_programs_compliance_criteria/models/g2p_cycle.py
+++ b/spp_programs_compliance_criteria/models/g2p_cycle.py
@@ -62,17 +62,6 @@ class G2pCycle(models.Model):
 
     def open_members_form(self):
         self.ensure_one()
-
-        action = {
-            "name": _("Cycle Beneficiaries"),
-            "type": "ir.actions.act_window",
-            "res_model": "g2p.cycle.membership",
-            "context": {
-                "create": False,
-                "default_cycle_id": self.id,
-                "search_default_enrolled_state": 1,
-            },
-            "view_mode": "list,form",
-            "domain": [("cycle_id", "=", self.id)],
-        }
+        action = super().open_members_form()
+        action["name"] = _("Cycle Beneficiaries")
         return action

--- a/spp_programs_compliance_criteria/models/g2p_cycle.py
+++ b/spp_programs_compliance_criteria/models/g2p_cycle.py
@@ -59,3 +59,20 @@ class G2pCycle(models.Model):
             "domain": [("cycle_id", "=", self.id)],
         }
         return action
+
+    def open_members_form(self):
+        self.ensure_one()
+
+        action = {
+            "name": _("Cycle Beneficiaries"),
+            "type": "ir.actions.act_window",
+            "res_model": "g2p.cycle.membership",
+            "context": {
+                "create": False,
+                "default_cycle_id": self.id,
+                "search_default_enrolled_state": 1,
+            },
+            "view_mode": "list,form",
+            "domain": [("cycle_id", "=", self.id)],
+        }
+        return action

--- a/spp_programs_compliance_criteria/models/g2p_cycle.py
+++ b/spp_programs_compliance_criteria/models/g2p_cycle.py
@@ -7,6 +7,7 @@ class G2pCycle(models.Model):
     _inherit = "g2p.cycle"
 
     allow_filter_compliance_criteria = fields.Boolean(compute="_compute_allow_filter_compliance_criteria")
+    all_members_count = fields.Integer(string="# Enrollments", readonly=True, compute="_compute_all_members_count")
 
     @api.depends("program_id", "program_id.compliance_managers")
     def _compute_allow_filter_compliance_criteria(self):
@@ -36,3 +37,25 @@ class G2pCycle(models.Model):
             membership = self.cycle_membership_ids if self.cycle_membership_ids else None
             domain.append(manager_ref._prepare_eligible_domain(membership))
         return OR(domain)
+
+    def _compute_all_members_count(self):
+        for rec in self:
+            domain = rec._get_beneficiaries_domain(None)
+            members_count = self.env["g2p.cycle.membership"].search_count(domain)
+            rec.update({"all_members_count": members_count})
+
+    def open_all_members_form(self):
+        self.ensure_one()
+
+        action = {
+            "name": _("Cycle Members"),
+            "type": "ir.actions.act_window",
+            "res_model": "g2p.cycle.membership",
+            "context": {
+                "create": False,
+                "default_cycle_id": self.id,
+            },
+            "view_mode": "list,form",
+            "domain": [("cycle_id", "=", self.id)],
+        }
+        return action

--- a/spp_programs_compliance_criteria/views/g2p_cycle_views.xml
+++ b/spp_programs_compliance_criteria/views/g2p_cycle_views.xml
@@ -18,6 +18,21 @@
                 />
                 <field name="allow_filter_compliance_criteria" invisible="1" />
             </xpath>
+
+            <xpath expr="//button[@name='open_members_form']" position="before">
+                <button
+                    type="object"
+                    class="oe_stat_button"
+                    title="Open all members form"
+                    icon="fa-users"
+                    name="open_all_members_form"
+                >
+                    <div class="o_form_field o_stat_info">
+                        <field name="all_members_count" class="o_stat_value" />
+                        <span class="o_stat_text">Enrollments</span>
+                    </div>
+                </button>
+            </xpath>
         </field>
     </record>
 

--- a/spp_programs_compliance_criteria/views/g2p_cycle_views.xml
+++ b/spp_programs_compliance_criteria/views/g2p_cycle_views.xml
@@ -24,7 +24,7 @@
                     type="object"
                     class="oe_stat_button"
                     title="Open all members form"
-                    icon="fa-users"
+                    icon="fa-list-alt"
                     name="open_all_members_form"
                 >
                     <div class="o_form_field o_stat_info">


### PR DESCRIPTION
## **Why is this change needed?**
To be able to view all members (Even non-compliant members) on Cycle View.

## **How was the change implemented?**
Added a button and function to open the list of members without the added filter, also added a new count field to count all members.

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
- Install or Upgrade `spp_programs_compliance_criteria`.
- Open or Create new program (Make sure to add some compliance criteria).
- Open or Create new cycle.
- Check if Enrollments Button on top (Before `Beneficiaries`) exists.
- Click on Compliance Criteria and check if the `Enrollments` Count is still the same.
- Compare the List from `Beneficiaries` and `Enrollments` if it is the expected behavior.

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/649
