### PR TITLE
add ability to choose which program UI a program should use

### DIFF
--- a/spp_programs/__manifest__.py
+++ b/spp_programs/__manifest__.py
@@ -39,6 +39,7 @@
     "assets": {
         "web.assets_backend": [
             "spp_programs/static/src/js/domain_field.js",
+            "spp_programs/static/src/js/custom_open_list.js",
         ],
     },
     "demo": [],

--- a/spp_programs/models/programs.py
+++ b/spp_programs/models/programs.py
@@ -12,6 +12,31 @@ class CustomG2PProgram(models.Model):
 
     is_one_time_distribution = fields.Boolean("One-time Distribution")
 
+    view_id = fields.Many2one(
+        "ir.ui.view",
+        "Program UI Template",
+        domain="[('model', '=', 'g2p.program'), " "('type', '=', 'form')," "('inherit_id', '=', False),]",
+        default=lambda self: self._get_default_program_ui(),
+    )
+
+    def _get_default_program_ui(self):
+        return self.env.ref("g2p_programs.view_program_list_form")
+
+    def open_program_form(self):
+        for rec in self:
+            view_id = self.env.ref("g2p_programs.view_program_list_form")
+            if rec.view_id:
+                view_id = rec.view_id
+
+            return {
+                "type": "ir.actions.act_window",
+                "res_model": "g2p.program",
+                "view_mode": "form",
+                "view_id": view_id.id,
+                "res_id": rec.id,
+                "target": "current",
+            }
+
     def import_eligible_registrants(self, state="draft"):
         eligibility_managers = self.get_managers(self.MANAGER_ELIGIBILITY)
         if eligibility_managers:

--- a/spp_programs/static/src/js/custom_open_list.js
+++ b/spp_programs/static/src/js/custom_open_list.js
@@ -1,0 +1,34 @@
+/** @odoo-module **/
+
+import {ListRenderer} from "@web/views/list/list_renderer";
+import {patch} from "@web/core/utils/patch";
+import {useService} from "@web/core/utils/hooks";
+
+patch(ListRenderer.prototype, {
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.actionService = useService("action");
+    },
+
+    async onCellClicked(record, column, ev) {
+        console.log(record);
+        if (record.resModel === "g2p.program") {
+            var result = await this.orm.call("g2p.program", "open_program_form", [record.resId]);
+            this.actionService.doAction(
+                {
+                    name: result.name,
+                    type: "ir.actions.act_window",
+                    res_model: result.res_model,
+                    views: [[result.view_id, "form"]],
+                    res_id: result.res_id,
+                    target: result.target,
+                    context: result.context,
+                },
+                {clear_breadcrumbs: true}
+            );
+        } else {
+            super.onCellClicked(record, column, ev);
+        }
+    },
+});

--- a/spp_programs/views/programs_view.xml
+++ b/spp_programs/views/programs_view.xml
@@ -136,5 +136,11 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
             </xpath>
         </field>
     </record>
+    <record id="g2p_programs.view_program_list_form" model="ir.ui.view">
+        <field name="name">Default Program UI Template</field>
+    </record>
+    <record id="g2p_programs.action_program_list" model="ir.actions.act_window">
+        <field name="context">{}</field>
+    </record>
 
 </odoo>

--- a/spp_programs/wizard/create_program_wizard.py
+++ b/spp_programs/wizard/create_program_wizard.py
@@ -29,6 +29,15 @@ class SPPCreateNewProgramWiz(models.TransientModel):
     )
 
     id_type = fields.Many2one("g2p.id.type", "ID Type to store in entitlements")
+    view_id = fields.Many2one(
+        "ir.ui.view",
+        "Program UI Template",
+        domain="[('model', '=', 'g2p.program'), " "('type', '=', 'form')," "('inherit_id', '=', False),]",
+        default=lambda self: self._get_default_program_ui(),
+    )
+
+    def _get_default_program_ui(self):
+        return self.env.ref("g2p_programs.view_program_list_form")
 
     @api.onchange("admin_area_ids")
     def on_admin_area_ids_change(self):
@@ -102,15 +111,22 @@ class SPPCreateNewProgramWiz(models.TransientModel):
             if rec.is_one_time_distribution:
                 program.create_new_cycle()
 
+            view_id = self.env.ref("g2p_programs.view_program_list_form")
+            if rec.view_id:
+                view_id = rec.view_id
+
+            program.view_id = view_id.id
+
             # Open the newly created program
-            action = {
+            return {
                 "name": _("Programs"),
-                "type": "ir.actions.act_window",
+                "view_mode": "form",
                 "res_model": "g2p.program",
-                "view_mode": "form,list",
                 "res_id": program_id,
+                "view_id": view_id.id,
+                "type": "ir.actions.act_window",
+                "target": "current",
             }
-            return action
 
     def _get_default_eligibility_manager_val(self, program_id):
         return {

--- a/spp_programs/wizard/create_program_wizard.xml
+++ b/spp_programs/wizard/create_program_wizard.xml
@@ -59,6 +59,9 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                     state == 'step1'
                 </attribute>
             </xpath>
+            <xpath expr="//field[@name='currency_id']" position="after">
+                <field name="view_id" options="{'no_open':true,'no_create':true,'no_create_edit':true}" />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
## **Why is this change needed?**
Add a functionality to be able to choose a program UI for a program.

## **How was the change implemented?**
Added new field in program and program creation wizard and created a JS to open the correct program UI.

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
- Install or Upgrade `spp_programs`.
- Go to Programs > Create new Program.
- Under the Currency Field should be a new field called `Program UI Template`, select one (although this is the generic part the default program UI should be the only one in the selection).
- Check if the correct UI is shown when the program is created.

**Note: This is the generic part so there should be no other UI except for the default on the selection, hence no other changed behavior is expected when testing this as the default UI will be the one shown when opening or creating a program.

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/555
