### PR TITLE
fix starter for demo modules

### DIFF
--- a/spp_starter/wizards/spp_starter.py
+++ b/spp_starter/wizards/spp_starter.py
@@ -217,7 +217,8 @@ class SppStarter(models.TransientModel):
             res |= find_module("spp_change_request_change_info")
             res |= find_module("spp_event_data")
             if self.sp_mis_demo_management == "yes":
-                res |= find_module("spp_demo")
+                res |= find_module("spp_base_demo")
+                res |= find_module("spp_mis_demo")
             if self.location_assignment == "yes":
                 res |= find_module("spp_area")
             if self.service_point_management == "yes":
@@ -235,6 +236,7 @@ class SppStarter(models.TransientModel):
             if self.location_assignment == "yes":
                 res |= find_module("spp_area_gis")
             if self.farmer_demo_management == "yes":
+                res |= find_module("spp_base_demo")
                 res |= find_module("spp_farmer_registry_demo")
                 res |= find_module("spp_programs")
 


### PR DESCRIPTION
## **Why is this change needed?**
To fix the error when using `spp_starter` for demo.

## **How was the change implemented?**
Added `spp_base_demo` and renamed `spp_demo` to `spp_mis_demo`.

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
- On newly set instance or runboat install `spp_starter`.
- Proceed with the setup. (Try with SP-MIS and Farmer Registry, also make sure to test this as demo)
- If proceeded with no error then PR is done.

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/660
