### PR TITLE
[FIX] spp_entitlement_cash: access error

### DIFF
--- a/spp_entitlement_cash/security/ir.model.access.csv
+++ b/spp_entitlement_cash/security/ir.model.access.csv
@@ -9,3 +9,5 @@ g2p_prog_entitle_manager_cash_item_program_validator,Program Entitlement Manager
 
 g2p_program_create_wizard_entitlement_cash_item_admin,Create Program Wizard Entitlement Cash Items Admin Access,spp_entitlement_cash.model_g2p_program_create_wizard_entitlement_cash_item,g2p_registry_base.group_g2p_admin,1,1,1,1
 g2p_program_create_wizard_entitlement_cash_item_program_manager,Create Program Wizard Program Entitlement Cash Items Manager Access,spp_entitlement_cash.model_g2p_program_create_wizard_entitlement_cash_item,g2p_programs.g2p_program_manager,1,1,1,1
+
+g2p_ir_model_program_manager,Model Program Manager Access,base.model_ir_model,g2p_programs.g2p_program_manager,1,0,0,0


### PR DESCRIPTION
## **Why is this change needed?**

- On the SPMIS configuration instance, logging in as a Global Program Manager triggers an access error. Although this error can be dismissed by clicking outside the modal, it is currently reproducible only by users with the Global Program Manager role.

- As a Global Program Manager, attempting to access the multiplier dropdown from the Entitlement Manager for either CASH or IN-KIND results in an access error.

- Program manager role to be able to access the system and multiplier dropdown field to be able to configure it

## **How was the change implemented?**

This issue resolved by granting access to the Program Manager role.

## **New unit tests**
N/A

## **Unit tests executed by the author**
N/A

## **How to test manually**
1. Login using Program manager credentials
2. Should be able to access the system
3. Go to programs and create a program
4. While creating a program go to "Configure entitlement manager" and select either cash or in-kind
5. Click on add a line
6. Notice when clicking dropdown for multiplier
7. Able to access multiplier and configure it

## **Related links**
#646 and #647 
