### PR TITLE
[BUG] global: Disabling non-working GH Action workflows

### DIFF
--- a/.github/workflows/test-legacy.yml
+++ b/.github/workflows/test-legacy.yml
@@ -1,12 +1,6 @@
 name: tests (legacy)
 # fetching the OpenG2P dependencies from the OpenG2P repositories, using latest revision of branch 17.0/17.0-develop
 
-on:
-  push:
-    branches:
-      - "17.0"
-      - "17.0-ocabot-*"
-      - "farmer-registry"
 env:
   OCA_GIT_USER_NAME: openspp
   OCA_GIT_USER_EMAIL: bot@openspp.org

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -1,12 +1,6 @@
 name: tests (PyPI)
 # fetching the OpenG2P dependencies from OpenSPP PyPI, locked to the version of the OpenSPP 17.0.1.2 (batanes) release
 
-on:
-  push:
-    branches:
-      - "17.0"
-      - "17.0-ocabot-*"
-      - "farmer-registry"
 env:
   OCA_GIT_USER_NAME: openspp
   OCA_GIT_USER_EMAIL: bot@openspp.org


### PR DESCRIPTION
## **Why is this change needed?**
The broken GH Action workflows have been disabled to save time, avoid confusion, and save resources.

## **How was the change implemented?**
The `on` event triggers were removed, leaving manual execution of the workflow as the remaining possibility.

## **New unit tests**
N/A

## **Unit tests executed by the author**
N/A

## **How to test manually**
N/A

## **Related links**
N/A
