### PR TITLE
[chore] Require/use HTTPS

### DIFF
--- a/scripts/sync_issue_to_odoo.py
+++ b/scripts/sync_issue_to_odoo.py
@@ -16,8 +16,8 @@ def sanitize(input_string):
 
 # Ensure the URL is correctly formatted
 url = os.getenv("ODOO_URL")
-if not url.startswith("http://") and not url.startswith("https://"):
-    logger.error("Error: ODOO_URL should start with http:// or https://")
+if not url.startswith("https://"):
+    logger.error("Error: ODOO_URL should start with https://")
     sys.exit(1)
 
 db = os.getenv("ODOO_DB")

--- a/spp_registry_data_source/tests/test_data_source.py
+++ b/spp_registry_data_source/tests/test_data_source.py
@@ -9,7 +9,7 @@ class TestDataSource(TransactionCase):
         cls.data_source = cls.env["spp.data.source"].create(
             {
                 "name": "Test Data Source",
-                "url": "http://test.com",
+                "url": "https://test.com",
                 "auth_type": "basic_authentication",
             }
         )
@@ -53,5 +53,5 @@ class TestDataSource(TransactionCase):
     def test_get_source_path_id_key_full_path_pair(self):
         self.assertEqual(
             self.data_source.get_source_path_id_key_full_path_pair(),
-            {"test_path": "http://test.com/test"},
+            {"test_path": "https://test.com/test"},
         )


### PR DESCRIPTION
## **Why is this change needed?**
- The Odoo issue sync should not be allowed to run over HTTP
- The tests should use https in the URL to pass Sonarcloud checks
