### PR TITLE
[chore] Add SRI hashes to Swagger JS resources

### DIFF
--- a/spp_api/templates/index.html
+++ b/spp_api/templates/index.html
@@ -31,8 +31,16 @@
   </head>
   <body>
     <div id="swagger-ui"></div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.43.0/swagger-ui-bundle.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.43.0/swagger-ui-standalone-preset.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.43.0/swagger-ui-bundle.js"
+      integrity="sha384-Zb06Xc0oXkxn//IOQeob2LVug137MWHyTqBlGlgwHShuRQSMuhYrRg86+lP7V42k"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.43.0/swagger-ui-standalone-preset.js"
+      integrity="sha384-BsitqhHkErSN9b/iun/R1Y86U5FBoto5k91hn7C7kNr+Ok007o8deuhnb3/AaXK7"
+      crossorigin="anonymous"
+    ></script>
     <script>
       window.onload = function() {
           var spec = %s;


### PR DESCRIPTION
## **Why is this change needed?**
Using SRI when loading CDN JavaScript ensures that we get the expected script.

By ensuring that a remote artifact is exactly what it is supposed to be before using it, the application is protected from unexpected changes applied to it before it is downloaded.

Especially, integrity checks will allow for identifying an artifact replaced by malware on the publication website or that was legitimately changed by its author, in a more benign scenario.
