### PR TITLE
[FIX] spp_entitlement_cash: fix maximum amount bug

### DIFF
--- a/spp_entitlement_cash/models/entitlement_manager.py
+++ b/spp_entitlement_cash/models/entitlement_manager.py
@@ -123,9 +123,8 @@ class G2PCashEntitlementManager(models.Model):
                 if beneficiary_id.id in new_entitlements_to_create:
                     amount = amount + new_entitlements_to_create[beneficiary_id.id]["initial_amount"]
                 # Check if amount > max_amount; ignore if max_amount is set to 0
-                if self.max_amount > 0.0:
-                    if amount > self.max_amount:
-                        amount = self.max_amount
+                if self.max_amount > 0.0 and amount > self.max_amount:
+                    amount = self.max_amount
 
                 new_entitlements_to_create[beneficiary_id.id] = {
                     "cycle_id": cycle.id,
@@ -190,9 +189,8 @@ class G2PCashEntitlementManager(models.Model):
     def _check_subsidy(self, amount):
         # Check if initial_amount > max_amount then set = max_amount
         # Ignore if max_amount is set to 0
-        if self.max_amount > 0.0:
-            if amount > self.max_amount:
-                return self.max_amount
+        if self.max_amount > 0.0 and amount > self.max_amount:
+            return self.max_amount
         return amount
 
     def set_pending_validation_entitlements(self, cycle):

--- a/spp_entitlement_cash/models/entitlement_manager.py
+++ b/spp_entitlement_cash/models/entitlement_manager.py
@@ -77,6 +77,7 @@ class G2PCashEntitlementManager(models.Model):
 
         new_entitlements_to_create = {}
         for rec in self.entitlement_item_ids:
+            _logger.info(f"Rec Amount: {rec.amount}")
             if rec.condition:
                 beneficiaries_ids = self._get_all_beneficiaries(
                     all_beneficiaries_ids, rec.condition, self.evaluate_one_item
@@ -187,10 +188,10 @@ class G2PCashEntitlementManager(models.Model):
         return all_beneficiaries_ids
 
     def _check_subsidy(self, amount):
-        # Check if initial_amount < max_amount then set = max_amount
+        # Check if initial_amount > max_amount then set = max_amount
         # Ignore if max_amount is set to 0
         if self.max_amount > 0.0:
-            if amount < self.max_amount:
+            if amount > self.max_amount:
                 return self.max_amount
         return amount
 

--- a/spp_entitlement_cash/models/entitlement_manager.py
+++ b/spp_entitlement_cash/models/entitlement_manager.py
@@ -84,6 +84,7 @@ class G2PCashEntitlementManager(models.Model):
                 )
             else:
                 beneficiaries_ids = all_beneficiaries_ids
+            _logger.info(f"Beneficiaries IDs: {beneficiaries_ids}")
 
             beneficiaries_with_entitlements = (
                 self.env["g2p.entitlement"]
@@ -117,6 +118,7 @@ class G2PCashEntitlementManager(models.Model):
                     multiplier = 1
                 if rec.max_multiplier > 0 and multiplier > rec.max_multiplier:
                     multiplier = rec.max_multiplier
+                _logger.info(f"Multiplier: {multiplier}")
                 amount = rec.amount * float(multiplier)
 
                 # Compute the sum of cash entitlements

--- a/spp_entitlement_cash/tests/test_entitlement_manager.py
+++ b/spp_entitlement_cash/tests/test_entitlement_manager.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import date
 from unittest.mock import patch
 
@@ -5,8 +6,12 @@ from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests import TransactionCase
 
+_logger = logging.getLogger(__name__)
+
 
 class TestEntitlementManager(TransactionCase):
+    GROUP_KIND_HOUSEHOLD = "g2p_registry_group.group_kind_household"
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -21,6 +26,32 @@ class TestEntitlementManager(TransactionCase):
                     "name": "Registrant 2 [TEST]",
                     "is_registrant": True,
                     "is_group": True,
+                },
+            ]
+        )
+        cls.individuals = cls.env["res.partner"].create(
+            [
+                {
+                    "name": "Individual 1 [TEST]",
+                    "is_registrant": True,
+                    "is_group": False,
+                },
+                {
+                    "name": "Individual 2 [TEST]",
+                    "is_registrant": True,
+                    "is_group": False,
+                },
+            ]
+        )
+        cls.env["g2p.group.membership"].create(
+            [
+                {
+                    "individual": cls.individuals[0].id,
+                    "group": cls.registrants[0].id,
+                },
+                {
+                    "individual": cls.individuals[1].id,
+                    "group": cls.registrants[0].id,
                 },
             ]
         )
@@ -84,19 +115,14 @@ class TestEntitlementManager(TransactionCase):
         )
 
     def test_01_prepare_entitlements(self):
+        # Test case 1: No items entered
         with self.assertRaisesRegex(UserError, "no items entered for this"):
             self._cash_entitlement_manager.prepare_entitlements(self.cycle, self.program.program_membership_ids)
+
+        # Test case 2: Basic entitlement creation
         self._cash_entitlement_manager.write(
             {
-                "entitlement_item_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "amount": 5.0,
-                        },
-                    ),
-                ],
+                "entitlement_item_ids": [(0, 0, {"amount": 5.0})],
             }
         )
         before_entitlement = self.env["g2p.entitlement"].search([])
@@ -119,7 +145,9 @@ class TestEntitlementManager(TransactionCase):
     def test_03_validate_entitlements(self, mock_today):
         mock_today.__name__ = "mock_today"
         mock_today.return_value = date(2023, 5, 23)
-        self.create_entitlement()
+        entitlement = self.create_entitlement()
+
+        # Test case 1: No funding
         res = self._cash_entitlement_manager.validate_entitlements(self.cycle)
         self.assertEqual(
             res["params"]["type"],
@@ -127,17 +155,18 @@ class TestEntitlementManager(TransactionCase):
             "Should display danger notification [no fund]!",
         )
 
-        # Note: Removed this test case to fix issue on code coverage
-        # TODO: Fix this test case
-        # self._funding()
-        # res = self._cash_entitlement_manager.validate_entitlements(self.cycle)
-        # self.assertEqual(res["params"]["type"], "success", "Should display success notification!")
-        # self.assertEqual(entitlement.state, "approved", "Entitlement should now approved!")
-        # self.assertEqual(
-        #     entitlement.date_approved,
-        #     date(2023, 5, 23),
-        #     "Entitlement approving date should be today!",
-        # )
+        # Test case 2: With funding and transfer fee
+        self._funding()
+        entitlement.write({"transfer_fee": 1.0})
+        res = self._cash_entitlement_manager.validate_entitlements(self.cycle)
+        self.assertEqual(res["params"]["type"], "success", "Should display success notification!")
+        self.assertEqual(entitlement.state, "approved", "Entitlement should now be approved!")
+        self.assertTrue(entitlement.service_fee_disbursement_id, "Service fee payment should be created!")
+        self.assertEqual(entitlement.service_fee_disbursement_id.amount, 1.0, "Service fee amount should be correct!")
+
+        # Test case 3: Invalid state validation
+        entitlement2 = self.create_entitlement()
+        entitlement2.state = "approved"
 
     def test_04_cancel_entitlements(self):
         entitlement = self.create_entitlement()
@@ -162,3 +191,18 @@ class TestEntitlementManager(TransactionCase):
         self.assertEqual(res["target"], "new")
         self.assertEqual(res["res_id"], entitlement.id)
         self.assertEqual(res["view_mode"], "form")
+
+    def test_check_subsidy(self):
+        """Test the _check_subsidy method of cash entitlement manager"""
+        # Create a cash entitlement manager with max_amount = 100
+
+        # Test when amount is less than max_amount
+        self.assertEqual(self._cash_entitlement_manager._check_subsidy(50.0), 50.0)
+
+        # Test when amount is greater than max_amount
+        self._cash_entitlement_manager.max_amount = 100.0
+        self.assertEqual(self._cash_entitlement_manager._check_subsidy(150.0), 100.0)
+
+        # Test when max_amount is 0 (no limit)
+        self._cash_entitlement_manager.max_amount = 0.0
+        self.assertEqual(self._cash_entitlement_manager._check_subsidy(150.0), 150.0)


### PR DESCRIPTION
## **Why is this change needed?**
To fix the problem on Cash Entitlements where if Max amount was set the entitlements follows the Max amount value.

## **How was the change implemented?**
Fix the `_check_subsidy` function.

## **New unit tests**
```
TestEntitlementManager
```

## **Unit tests executed by the author**
```
TestEntitlementManager
```

## **How to test manually**
- Install or Upgrade `spp_entitlement_cash`.
- Create a Program with Cash as the Entitlement Manager and set the Max amount.
- Create Cycle and Prepare Entitlements.
- Check if the initial amount is correct.

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/728
