### PR TITLE
[FIX]  Add dvelopment_status

### DIFF
--- a/spp_custom_filter/__manifest__.py
+++ b/spp_custom_filter/__manifest__.py
@@ -4,6 +4,7 @@
     "version": "17.0.1.3.0",
     "summary": "Enhances Odoo's filtering system by allowing administrators to control which fields are displayed in filter dropdowns, improving user experience and data management.",
     "author": "OpenSPP.org",
+    "development_status": "Production/Stable",
     "maintainers": ["nhatnm0612"],
     "website": "https://github.com/OpenSPP/openspp-modules",
     "license": "LGPL-3",

--- a/spp_custom_filter_ui/__manifest__.py
+++ b/spp_custom_filter_ui/__manifest__.py
@@ -4,6 +4,7 @@
     "version": "17.0.1.3.0",
     "summary": "Customizes the OpenSPP UI to enhance filtering for Res Partners, improving usability and efficiency in managing registrants within social protection programs.",
     "author": "OpenSPP.org",
+    "development_status": "Production/Stable",
     "maintainers": ["nhatnm0612"],
     "website": "https://github.com/OpenSPP/openspp-modules",
     "license": "LGPL-3",


### PR DESCRIPTION
## **Why is this change needed?**
spp_custom_filter and spp_custom_filter_ui depends of spp_base, To match spp_base development status

## **How was the change implemented?**
Add the meta-data descriptor development_status in the __manifest__.py files of spp_custom_filter and spp_custom_filter_ui to Production/Stable.

## **New unit tests**

## **Unit tests executed by the author**

## **How to test manually**

## **Related links**
#741 
