### PR TITLE
[IMP] spp_entitlement_cash: alignment

### DIFF
--- a/spp_entitlement_cash/views/entitlement_manager_view.xml
+++ b/spp_entitlement_cash/views/entitlement_manager_view.xml
@@ -72,11 +72,17 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                                         widget="domain"
                                         options="{'model': 'res.partner'}"
                                     />
-                                    <field
-                                        name="multiplier_field"
-                                        options="{'no_open':True,'no_create':True,'no_create_edit':True}"
-                                    />
-                                    <field name="max_multiplier" />
+                                </group>
+                                <group colspan="4" col="4">
+                                    <group colspan="2">
+                                        <field
+                                            name="multiplier_field"
+                                            options="{'no_open':True,'no_create':True,'no_create_edit':True}"
+                                        />
+                                    </group>
+                                    <group colspan="2">
+                                        <field name="max_multiplier" />
+                                    </group>
                                 </group>
                             </form>
                         </field>


### PR DESCRIPTION
## **Why is this change needed?**
Maximum number field is not aligned properly

## **How was the change implemented?**
By grouping fields properly

## **New unit tests**
N/A

## **Unit tests executed by the author**
N/A

## **How to test manually**
1. Create a program in OpenSPP with "Cash" as the entitlement manager.
2. Open the program, go to the Configuration tab, and click Entitlement Manager.
3. In the Cash Entitlement Manager modal, click Add a line.
4. Notice that the maximum number label is aligned with its input field.
<img width="1016" alt="Screenshot 2025-03-20 at 18 49 20" src="https://github.com/user-attachments/assets/74061297-3a1c-44ca-bb02-385710992f71" />


## **Related links**
#729 
