### PR TITLE
[ADD] spp_change_request_event_data

### DIFF
--- a/spp_change_request_event_data/__init__.py
+++ b/spp_change_request_event_data/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/spp_change_request_event_data/__manifest__.py
+++ b/spp_change_request_event_data/__manifest__.py
@@ -1,0 +1,22 @@
+{
+    "name": "OpenSPP Change Request Event Data",
+    "category": "OpenSPP",
+    "version": "17.0.1.0.0",
+    "sequence": 1,
+    "author": "OpenSPP.org",
+    "website": "https://github.com/OpenSPP/openspp-modules",
+    "license": "LGPL-3",
+    "development_status": "Beta",
+    "maintainers": ["shashikala1998"],
+    "depends": [
+        "spp_event_data",
+        "spp_change_request",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/change_request_view.xml",
+    ],
+    "application": False,
+    "installable": True,
+    "auto_install": False,
+}

--- a/spp_change_request_event_data/models/__init__.py
+++ b/spp_change_request_event_data/models/__init__.py
@@ -1,0 +1,2 @@
+from . import change_request
+from . import event_data

--- a/spp_change_request_event_data/models/change_request.py
+++ b/spp_change_request_event_data/models/change_request.py
@@ -1,0 +1,63 @@
+import logging
+
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class ChangeRequest(models.Model):
+    _inherit = "spp.change.request"
+
+    event_data_ids = fields.One2many(
+        "spp.event.data",
+        "change_request_id",
+        string="Event History",
+    )
+
+    def write(self, vals):
+        """Override to track state changes and create event data"""
+        _logger.info("Writing change request: %s with vals: %s", self.name, vals)
+
+        res = super().write(vals)
+
+        # If state is changing to validated or applied, create/update event data
+        new_state = vals.get("state")
+        if new_state in ["validated", "applied"]:
+            for record in self:
+                if record.request_type_ref_id:
+                    _logger.info("Creating/Updating event data for state change to %s", new_state)
+
+                    # Get model and res_id from request_type_ref_id
+                    ref_model = record.request_type_ref_id._name
+                    ref_id = record.request_type_ref_id.id
+
+                    # Get the user who performed the action
+                    user = self.env.user.name
+
+                    # Check if an event already exists for this change request
+                    existing_event = self.env["spp.event.data"].search(
+                        [("change_request_id", "=", record.id), ("model", "=", ref_model), ("res_id", "=", ref_id)],
+                        limit=1,
+                    )
+
+                    event_vals = {
+                        "model": ref_model,
+                        "res_id": ref_id,
+                        "partner_id": record.registrant_id.id,
+                        "registrar": user,
+                        "state": "active",
+                        "change_request_id": record.id,
+                        "collection_date": fields.Date.today(),
+                        "event_type": new_state.capitalize(),  # 'Validated' or 'Applied'
+                    }
+
+                    if existing_event:
+                        # Update existing event
+                        existing_event.write(event_vals)
+                        _logger.info("Updated event data: %s", existing_event.id)
+                    else:
+                        # Create new event
+                        event = self.env["spp.event.data"].create(event_vals)
+                        _logger.info("Created event data: %s", event.id)
+
+        return res

--- a/spp_change_request_event_data/models/event_data.py
+++ b/spp_change_request_event_data/models/event_data.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class EventData(models.Model):
+    _inherit = "spp.event.data"
+
+    change_request_id = fields.Many2one(
+        "spp.change.request",
+        string="Change Request",
+        ondelete="set null",
+    )

--- a/spp_change_request_event_data/pyproject.toml
+++ b/spp_change_request_event_data/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/spp_change_request_event_data/security/ir.model.access.csv
+++ b/spp_change_request_event_data/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_spp_event_data_change_request_validator,SPP Event Data Change Request Validator Access,spp_event_data.model_spp_event_data,spp_change_request.group_spp_change_request_validator,1,1,1,0
+access_spp_event_data_change_request_hq_validator,SPP Event Data Change Request HQ Validator Access,spp_event_data.model_spp_event_data,spp_change_request.group_spp_change_request_hq_validator,1,1,1,0
+access_spp_event_data_change_request_applicator,SPP Event Data Change Request Applicator Access,spp_event_data.model_spp_event_data,spp_change_request.group_spp_change_request_applicator,1,1,1,0

--- a/spp_change_request_event_data/views/change_request_view.xml
+++ b/spp_change_request_event_data/views/change_request_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Inherit change request form view to add event data tab -->
+    <record id="view_change_request_form_inherit_event_data" model="ir.ui.view">
+        <field name="name">spp.change.request.form.inherit.event.data</field>
+        <field name="model">spp.change.request</field>
+        <field name="inherit_id" ref="spp_change_request.view_change_request_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="inside">
+                <notebook>
+                    <page string="Event History" name="event_history">
+                        <field
+                            name="event_data_ids"
+                            readonly="1"
+                            context="{'default_change_request_id': active_id}"
+                        >
+                            <tree>
+                                <field name="partner_id" />
+                                <field name="event_type" />
+                                <field name="collection_date" />
+                                <field name="registrar" />
+                                <field name="state" widget="badge" />
+                            </tree>
+                        </field>
+                    </page>
+                </notebook>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## **Why is this change needed?**
When approving a change request,An event data to update

## **How was the change implemented?**
1. Inherit spp_event_data and spp_change_request modules and add event data page on notebook of change request. Once approve a change request data will be save on event data section on change request

## **New unit tests**
N/A

## **Unit tests executed by the author**
N/A

## **How to test manually**
1. In a fresh database install spp_event_data and spp_change_request modules or install spp_change_request_event_data then other dependency modules will install automatically.
2. Define user roles to users
3. Create a change request (ex: add farmer CR, update farmer CR)
4. once approve the CR, system will automatically create event data on relevant change request
<img width="1434" alt="Screenshot 2025-03-25 at 22 24 31" src="https://github.com/user-attachments/assets/03610084-2e89-46d7-a43d-f9e40c5fd553" />


## **Related links**
#714 
