### PR TITLE
Fixing coverage issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,9 +180,10 @@ jobs:
           COVERAGE_FILE: ".coverage-farmer"
           EXCLUDE: "fastapi,g2p_auth_id_oidc,g2p_auth_oidc,g2p_bank,g2p_bank_rest_api,g2p_change_log,g2p_disable_password_login,g2p_encryption,g2p_encryption_keymanager,g2p_encryption_rest_api,g2p_entitlement_differential,g2p_entitlement_in_kind,g2p_entitlement_voucher,g2p_enumerator,g2p_formio,g2p_mis_importer,g2p_mts,g2p_notifications_base,g2p_notifications_fast2sms,g2p_notifications_voucher,g2p_notifications_wiserv,g2p_odk_importer,g2p_odk_importer_program,g2p_odk_user_mapping,g2p_openid_vci,g2p_openid_vci_programs,g2p_openid_vci_rest_api,g2p_payment_cash,g2p_payment_files,g2p_payment_g2p_connect,g2p_payment_interop_layer,g2p_payment_phee,g2p_payment_simple_mpesa,g2p_portal_auth,g2p_profile_image,g2p_program_approval,g2p_program_assessment,g2p_program_autoenrol,g2p_program_cycleless,g2p_program_documents,g2p_program_registrant_info,g2p_program_reimbursement,g2p_programs,g2p_proxy_means_test,g2p_registry_addl_info,g2p_registry_base,g2p_registry_encryption,g2p_registry_group,g2p_registry_individual,g2p_registry_membership,g2p_registry_rest_api,g2p_service_provider_beneficiary_management,g2p_service_provider_portal_base,g2p_social_registry_importer,g2p_superset_dashboard,g2p_theme,mts_connector,muk_product,muk_web_appsbar,muk_web_chatter,muk_web_colors,muk_web_dialog,muk_web_theme,spp_user_roles,spp_base,spp_mis_demo,spp_registrant_import,spp_change_request_add_children_demo,spp_manual_entitlement,spp_change_request_create_group"
         run: oca_run_tests
+      - name: Combine coverage data
+        run: coverage combine .coverage-mis .coverage-farmer
       - uses: codecov/codecov-action@v5
         with:
-          files: .coverage-mis,.coverage-farmer
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Update .pot files
         run: oca_export_and_push_pot https://x-access-token:${{ secrets.GIT_PUSH_TOKEN }}@github.com/${{ github.repository }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,6 +163,7 @@ jobs:
           rm -rf /opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/g2p_registry_individual/tests
       - name: Run SP-MIS tests
         env:
+          COVERAGE_FILE: ".coverage-mis"
           EXCLUDE: "fastapi,g2p_auth_id_oidc,g2p_auth_oidc,g2p_bank,g2p_bank_rest_api,g2p_change_log,g2p_disable_password_login,g2p_encryption,g2p_encryption_keymanager,g2p_encryption_rest_api,g2p_entitlement_differential,g2p_entitlement_in_kind,g2p_entitlement_voucher,g2p_enumerator,g2p_formio,g2p_mis_importer,g2p_mts,g2p_notifications_base,g2p_notifications_fast2sms,g2p_notifications_voucher,g2p_notifications_wiserv,g2p_odk_importer,g2p_odk_importer_program,g2p_odk_user_mapping,g2p_openid_vci,g2p_openid_vci_programs,g2p_openid_vci_rest_api,g2p_payment_cash,g2p_payment_files,g2p_payment_g2p_connect,g2p_payment_interop_layer,g2p_payment_phee,g2p_payment_simple_mpesa,g2p_portal_auth,g2p_profile_image,g2p_program_approval,g2p_program_assessment,g2p_program_autoenrol,g2p_program_cycleless,g2p_program_documents,g2p_program_registrant_info,g2p_program_reimbursement,g2p_programs,g2p_proxy_means_test,g2p_registry_addl_info,g2p_registry_base,g2p_registry_encryption,g2p_registry_group,g2p_registry_individual,g2p_registry_membership,g2p_registry_rest_api,g2p_service_provider_beneficiary_management,g2p_service_provider_portal_base,g2p_social_registry_importer,g2p_superset_dashboard,g2p_theme,mts_connector,muk_product,muk_web_appsbar,muk_web_chatter,muk_web_colors,muk_web_dialog,muk_web_theme,spp_user_roles,spp_change_request_add_farmer,spp_farmer_registry_base,spp_farmer_registry_dashboard,spp_farmer_registry_default_ui,spp_farmer_registry_demo,spp_custom_filter_farmer_registry,spp_registrant_import,spp_manual_entitlement,spp_change_request_create_farm,spp_change_request_edit_farmer,spp_change_request_edit_farm"
         run: oca_run_tests
       - name: Initialize farmer_registry db
@@ -176,10 +177,12 @@ jobs:
       - name: Run Farmer Registry tests
         env:
           PGDATABASE: farmer_registry
+          COVERAGE_FILE: ".coverage-farmer"
           EXCLUDE: "fastapi,g2p_auth_id_oidc,g2p_auth_oidc,g2p_bank,g2p_bank_rest_api,g2p_change_log,g2p_disable_password_login,g2p_encryption,g2p_encryption_keymanager,g2p_encryption_rest_api,g2p_entitlement_differential,g2p_entitlement_in_kind,g2p_entitlement_voucher,g2p_enumerator,g2p_formio,g2p_mis_importer,g2p_mts,g2p_notifications_base,g2p_notifications_fast2sms,g2p_notifications_voucher,g2p_notifications_wiserv,g2p_odk_importer,g2p_odk_importer_program,g2p_odk_user_mapping,g2p_openid_vci,g2p_openid_vci_programs,g2p_openid_vci_rest_api,g2p_payment_cash,g2p_payment_files,g2p_payment_g2p_connect,g2p_payment_interop_layer,g2p_payment_phee,g2p_payment_simple_mpesa,g2p_portal_auth,g2p_profile_image,g2p_program_approval,g2p_program_assessment,g2p_program_autoenrol,g2p_program_cycleless,g2p_program_documents,g2p_program_registrant_info,g2p_program_reimbursement,g2p_programs,g2p_proxy_means_test,g2p_registry_addl_info,g2p_registry_base,g2p_registry_encryption,g2p_registry_group,g2p_registry_individual,g2p_registry_membership,g2p_registry_rest_api,g2p_service_provider_beneficiary_management,g2p_service_provider_portal_base,g2p_social_registry_importer,g2p_superset_dashboard,g2p_theme,mts_connector,muk_product,muk_web_appsbar,muk_web_chatter,muk_web_colors,muk_web_dialog,muk_web_theme,spp_user_roles,spp_base,spp_mis_demo,spp_registrant_import,spp_change_request_add_children_demo,spp_manual_entitlement,spp_change_request_create_group"
         run: oca_run_tests
       - uses: codecov/codecov-action@v5
         with:
+          files: .coverage-mis,.coverage-farmer
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Update .pot files
         run: oca_export_and_push_pot https://x-access-token:${{ secrets.GIT_PUSH_TOKEN }}@github.com/${{ github.repository }}


### PR DESCRIPTION
## **Why is this change needed?**
Coverage (through CodeCov) was only taking the farmer test output into account. This change combines the MIS execution with the Farmer execution.

## **How was the change implemented?**
By combining the output for each run into a single coverage file which is then picked up by CodeCov as usual.

## **New unit tests**
None

## **Unit tests executed by the author**
All

## **How to test manually**
N/A

## **Related links**
N/A
