### PR TITLE
Removing demo data URL for the CRVS import module

### DIFF
--- a/spp_import_dci_api/data/crvs_data_source.xml
+++ b/spp_import_dci_api/data/crvs_data_source.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="spp_crvs_data_source" model="spp.data.source">
         <field name="name">CRVS</field>
-        <field name="url">https://dci.opencrvs.lab.cdpi.dev</field>
+        <field name="url">https://--Not Set--</field>
         <field name="auth_type">bearer_authentication</field>
     </record>
     <record id="spp_crvs_registry_path" model="spp.data.source.path">

--- a/spp_import_dci_api/tests/test_fetch_crvs_beneficiary.py
+++ b/spp_import_dci_api/tests/test_fetch_crvs_beneficiary.py
@@ -188,7 +188,7 @@ class TestFetchCRVSBeneficiary(TransactionCase):
         paths = self.fetch_crvs_beneficiary_id.get_data_source_paths()
         search_url = self.fetch_crvs_beneficiary_id.get_crvs_search_url(paths)
 
-        self.assertEqual(search_url, "https://dci.opencrvs.lab.cdpi.dev/registry/sync/search")
+        self.assertEqual(search_url, "https://--Not Set--/registry/sync/search")
 
     def test_get_crvs_auth_url(self):
         paths = self.fetch_crvs_beneficiary_id.get_data_source_paths()


### PR DESCRIPTION
## **Why is this change needed?**
- To reduce the wait for URL timeout during module initialization
- To prevent something unexpected from responding to that DNS

## **How was the change implemented?**
The URL has been replaced with placeholder data, which should trigger an error since it is not a valid URI

## **New unit tests**
N/A

## **Unit tests executed by the author**
Entire test suite

## **How to test manually**
1. Install the OpenSPP DCI Import API
2. Validate that the data source CRVS field is set to `--Not Set--`

## **Related links**

N/A