### PR TITLE
[FIX] spp_openid_vci: Fix issue card server action not showing

### DIFF
--- a/spp_openid_vci/views/registrant_view.xml
+++ b/spp_openid_vci/views/registrant_view.xml
@@ -3,6 +3,7 @@
     <record model="ir.actions.server" id="vc_modal_generator">
         <field name="name">Issue Card</field>
         <field name="model_id" ref="base.model_res_partner" />
+        <field name="binding_model_id" ref="base.model_res_partner" />
         <field name="binding_view_types">list</field>
         <field name="state">code</field>
         <field name="code">action = model.registry_issue_card()</field>


### PR DESCRIPTION
## **Why is this change needed?**

`Issue Card` server action is not showing.

## **How was the change implemented?**

Added binding model

## **New unit tests**

None

## **Unit tests executed by the author**

None

## **How to test manually**

- Install `spp_openid_vci_individual`
- Go to Registry -> Individual
- select atleast 1 record then click Action button
- `Issue Card` server action must be showing.

## **Related links**

