### PR TITLE
[IMP] spp_openid_vci: close windown when clicking confirm button

### DIFF
--- a/spp_openid_vci/wizard/vci_issuer_selection_view.xml
+++ b/spp_openid_vci/wizard/vci_issuer_selection_view.xml
@@ -15,7 +15,13 @@
 
                 </sheet>
                 <footer>
-                    <button name="issue_card" string="Confirm" type="object" class="btn btn-success" />
+                    <button
+                        name="issue_card"
+                        string="Confirm"
+                        type="object"
+                        class="btn btn-success"
+                        close="1"
+                    />
                     <button string="Cancel" class="btn btn-danger" special="cancel" />
                 </footer>
             </form>


### PR DESCRIPTION
## **Why is this change needed?**

Issue Card modal is not closing after clicking confirm button

## **How was the change implemented?**

added `close="1"` parameter to the button.

## **New unit tests**

None

## **Unit tests executed by the author**

None

## **How to test manually**

- Install `spp_openid_vci_individual`
- Go to Registry -> Individual
- enter 1 record.
- click the `Issue Card` smart button
- click confirm button
- after the generation of the ID card, the modal should be automatically closed.

## **Related links**

