### PR TITLE
[chore] Update action to use CodeQLAction v3

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -3,10 +3,10 @@ name: "Code Scanning - Action"
 on:
   push:
     branches:
-      - "{{ odoo_version }}"
+      - "17.0"
   pull_request:
     branches:
-      - "{{ odoo_version }}"
+      - "17.0"
   schedule:
     #        ┌───────────── minute (0 - 59)
     #        │  ┌───────────── hour (0 - 23)

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
         # Override language selection by uncommenting this and choosing your languages
@@ -52,7 +52,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -66,7 +66,7 @@ jobs:
       #     make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
 
       - name: TruffleHog OSS
         if: env.BRANCH_NAME != github.event.repository.default_branch


### PR DESCRIPTION
CodeQL Action v2 was deprecated in Jan 2025, and has now been upgraded to use v3.

See: https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/
