### PR TITLE
[chore] Improve code-analysis execution

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -69,10 +69,17 @@ jobs:
         uses: github/codeql-action/analyze@v3
 
       - name: TruffleHog OSS
-        if: env.BRANCH_NAME != github.event.repository.default_branch
+        if: github.event_name == 'pull_request'
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
           extra_args: --debug --only-verified
+
+      - name: TruffleHog OSS (on push to 17.0)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/17.0'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          extra_args: --debug --only-verified # Scanning the entire repo


### PR DESCRIPTION
The analysis should run on commits when processing a PR, and on all files in 17.0 when running against the base branch.

