### PR TITLE
[chore] refactor function for clarity

### DIFF
--- a/spp_farmer_registry_base/models/group_membership.py
+++ b/spp_farmer_registry_base/models/group_membership.py
@@ -8,14 +8,22 @@ class G2PGroupMembership(models.Model):
     individual_gender = fields.Many2one("gender.type", related="individual.gender", readonly=True)
 
     def unlink(self):
-        for rec in self:
-            group_id = rec.group
-            res = super(G2PGroupMembership, rec).unlink()
-            if self.env.context.get("skip_head_check"):
-                return res
+        # Skip head check if specified in context
+        if self.env.context.get("skip_head_check"):
+            return super().unlink()
+
+        # Group records by their group to check head members
+        groups_to_check = self.mapped("group")
+
+        # Perform the unlink operation
+        result = super().unlink()
+
+        # Check if any group lost its head member
+        for group in groups_to_check:
             if (
                 self.env.ref("g2p_registry_membership.group_membership_kind_head").id
-                not in group_id.group_membership_ids.mapped("kind").ids
+                not in group.group_membership_ids.mapped("kind").ids
             ):
                 raise UserError(_("Farm must have a head member."))
-            return res
+
+        return result

--- a/spp_farmer_registry_base/tests/__init__.py
+++ b/spp_farmer_registry_base/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_farm
 from . import test_farm_season
+from . import test_group_membership

--- a/spp_farmer_registry_base/tests/test_group_membership.py
+++ b/spp_farmer_registry_base/tests/test_group_membership.py
@@ -1,0 +1,77 @@
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestG2PGroupMembership(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Set context to avoid job queue delay
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                test_queue_job_no_delay=True,
+            )
+        )
+
+        # Create test data
+        cls.individual_1 = cls.env["res.partner"].create(
+            {
+                "name": "Test Individual 1",
+                "is_group": False,
+                "is_registrant": True,
+            }
+        )
+        cls.individual_2 = cls.env["res.partner"].create(
+            {
+                "name": "Test Individual 2",
+                "is_group": False,
+                "is_registrant": True,
+            }
+        )
+        cls.group = cls.env["res.partner"].create(
+            {
+                "name": "Test Group",
+                "is_group": True,
+                "is_registrant": True,
+            }
+        )
+
+        # Get the head membership kind
+        cls.head_kind = cls.env.ref("g2p_registry_membership.group_membership_kind_head")
+
+        # Create memberships
+        cls.membership_1 = cls.env["g2p.group.membership"].create(
+            {
+                "group": cls.group.id,
+                "individual": cls.individual_1.id,
+                "kind": [(4, cls.head_kind.id)],
+            }
+        )
+        cls.membership_2 = cls.env["g2p.group.membership"].create(
+            {
+                "group": cls.group.id,
+                "individual": cls.individual_2.id,
+            }
+        )
+
+    def test_01_unlink_non_head_member(self):
+        """Test unlink of a non-head member"""
+        # Should be able to unlink non-head member
+        self.membership_2.unlink()
+        self.assertFalse(self.membership_2.exists())
+
+    def test_02_unlink_head_member_with_skip_context(self):
+        """Test unlink of head member with skip_head_check context"""
+        # Should be able to unlink head member with skip context
+        self.membership_1.with_context(skip_head_check=True).unlink()
+        self.assertFalse(self.membership_1.exists())
+
+    def test_03_unlink_head_member_without_skip_context(self):
+        """Test unlink of head member without skip_head_check context"""
+        # Should raise error when trying to unlink head member
+        with self.assertRaises(UserError):
+            self.membership_1.unlink()
+        self.assertTrue(self.membership_1.exists())


### PR DESCRIPTION
## **Why is this change needed?**
- The previous implementation used a for-loop but only handled the first record.
- The previous implementation returned the same value in two places
- The flow of the function was complex to read

## **How was the change implemented?**
- The function was refactored so that if the head check should be skipped, the unlink is directly performed through the super, and the result is returned immediately.
- The refactored function will process all records, if multiple records are provided

## **New unit tests**
None

## **Unit tests executed by the author**
All

## **How to test manually**
Open a farmer record, delete the head member, try to save.
