### PR TITLE
[chore] aligning development status

### DIFF
--- a/spp_hide_menus_base/__manifest__.py
+++ b/spp_hide_menus_base/__manifest__.py
@@ -9,6 +9,7 @@
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",
     "license": "LGPL-3",
+    "development_status": "Production/Stable",
     "maintainers": ["reichie020212"],
     "depends": ["base"],
     "data": [

--- a/spp_registry_base/__manifest__.py
+++ b/spp_registry_base/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",
     "license": "LGPL-3",
-    "development_status": "Beta",
+    "development_status": "Production/Stable",
     "maintainers": ["reichie020212"],
     "depends": [
         "base_import",


### PR DESCRIPTION
## **Why is this change needed?**
Aligning development status across modules where a "base" had been extracted from the initial module
