### PR TITLE
[FIX] Hide unneccessary options in actions

### DIFF
--- a/spp_base/__manifest__.py
+++ b/spp_base/__manifest__.py
@@ -51,6 +51,7 @@
         "security/ir.model.access.csv",
         "views/registrant_view.xml",
         "views/main_view.xml",
+        "views/users_view.xml",
     ],
     "assets": {},
     "demo": [],

--- a/spp_base/views/users_view.xml
+++ b/spp_base/views/users_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="base.action_partner_merge" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]" />
+    </record>
+    <record id="mail.action_partner_mass_mail" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]" />
+    </record>
+    <record id="sms.res_partner_act_window_sms_composer_multi" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]" />
+    </record>
+    <record model="ir.actions.server" id="web.download_contact">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]" />
+    </record>
+    <record model="ir.actions.server" id="portal.partner_wizard_action_create_and_open">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]" />
+    </record>
+
+</odoo>

--- a/spp_farmer_registry_base/__manifest__.py
+++ b/spp_farmer_registry_base/__manifest__.py
@@ -35,6 +35,7 @@
         "data/id_data.xml",
         "views/res_partner.xml",
         "views/configuration_view.xml",
+        "views/res_users.xml",
     ],
     "assets": {
         "web.assets_backend": [

--- a/spp_farmer_registry_base/views/res_users.xml
+++ b/spp_farmer_registry_base/views/res_users.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="base.action_partner_merge" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]" />
+    </record>
+    <record id="mail.action_partner_mass_mail" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]" />
+    </record>
+    <record id="sms.res_partner_act_window_sms_composer_multi" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]" />
+    </record>
+    <record model="ir.actions.server" id="web.download_contact">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]" />
+    </record>
+    <record model="ir.actions.server" id="portal.partner_wizard_action_create_and_open">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]" />
+    </record>
+
+</odoo>


### PR DESCRIPTION
## **Why is this change needed?**
Hide options in Actions:
- Merge
- Send Email
- Send SMS Test Message
- Download (vCard)
- Grant portal access

## **How was the change implemented?**
Added Admin in Action Groups, so only Admin can see this Options.

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
- After Deployment, Check (As any user except for user with Admin Settings Access) if those options in Action still exists.

## **Related links**

