### PR TITLE
fix: Remove 'Default' text from eligibility criteria tab label

### DIFF
--- a/spp_programs/wizard/create_program_wizard.xml
+++ b/spp_programs/wizard/create_program_wizard.xml
@@ -9,6 +9,9 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
         <field name="priority">1000</field>
         <field name="inherit_id" ref="g2p_programs.create_program_wizard_form_view" />
         <field name="arch" type="xml">
+            <xpath expr="//page[@name='eligibility']" position="attributes">
+                <attribute name="string">Configure the Eligibility Criteria</attribute>
+            </xpath>
             <xpath expr="//page[@name='eligibility']/group[1]" position="replace">
                 <group colspan="4" col="4">
                     <field


### PR DESCRIPTION
## Description
Removes the misleading "Default" text from the eligibility criteria configuration tab label.

## Changes
- Changed "Configure the Default Eligibility Criteria" to "Configure the Eligibility Criteria"
- Updated page string attribute in `spp_programs/wizard/create_program_wizard.xml`

## Why
The word "default" was misleading because these are actually types of eligibility criteria, not default ones. This makes the UI more accurate and user-friendly.

Fixes #722