### PR TITLE
fix: removed 'Default' from eligibility criteria (#722)

### DIFF
--- a/g2p_programs/i18n/g2p_programs.pot
+++ b/g2p_programs/i18n/g2p_programs.pot
@@ -1278,7 +1278,7 @@ msgstr ""
 
 #. module: g2p_programs
 #: model_terms:ir.ui.view,arch_db:g2p_programs.create_program_wizard_form_view
-msgid "Configure the Default Eligibility Criteria"
+msgid "Configure the Eligibility Criteria"
 msgstr ""
 
 #. module: g2p_programs


### PR DESCRIPTION
## **Why is this change needed?**
To improve clarity by removing the word “Default” from the eligibility criteria label.

## **How was the change implemented?**
Updated the "msgid" in the "g2p_programs.pot" file to remove the word “Default”.

## **New unit tests**
Not applicable.

## **Unit tests executed by the author**
Not applicable.

## **How to test manually**
Run Odoo and check if the label now shows “Configure the Eligibility Criteria”.

## **Related links**
Fixes #722
