### PR TITLE
Remove "Default" from Eligibility Criteria Configuration Label in Program Settings

### DIFF
--- a/g2p_programs/i18n/g2p_programs.pot
+++ b/g2p_programs/i18n/g2p_programs.pot
@@ -1278,7 +1278,7 @@ msgstr ""
 
 #. module: g2p_programs
 #: model_terms:ir.ui.view,arch_db:g2p_programs.create_program_wizard_form_view
-msgid "Configure the Eligibility Criteria"
+msgid "Configure the Default Eligibility Criteria"
 msgstr ""
 
 #. module: g2p_programs

--- a/g2p_programs/i18n/g2p_programs.pot
+++ b/g2p_programs/i18n/g2p_programs.pot
@@ -1278,7 +1278,7 @@ msgstr ""
 
 #. module: g2p_programs
 #: model_terms:ir.ui.view,arch_db:g2p_programs.create_program_wizard_form_view
-msgid "Configure the Default Eligibility Criteria"
+msgid "Configure the Eligibility Criteria"
 msgstr ""
 
 #. module: g2p_programs

--- a/spp_programs/wizard/create_program_wizard.xml
+++ b/spp_programs/wizard/create_program_wizard.xml
@@ -9,6 +9,10 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
         <field name="priority">1000</field>
         <field name="inherit_id" ref="g2p_programs.create_program_wizard_form_view" />
         <field name="arch" type="xml">
+            <xpath expr="//page[@name='eligibility']" position="attributes">
+                <attribute name="string">Configure the Eligibility Criteria</attribute>
+            </xpath>
+            
             <xpath expr="//page[@name='eligibility']/group[1]" position="replace">
                 <group colspan="4" col="4">
                     <field


### PR DESCRIPTION
## **Why is this change needed?**
The label "Configure the Default Eligibility Criteria" in the Program Settings modal (see screenshot) is confusing and does not match current requirements. Removing "Default" clarifies the purpose and aligns with user expectations.
This change addresses issue #722.

## **How was the change implemented?**
Updated the English source string in g2p_programs.pot from "Configure the Default Eligibility Criteria" to "Configure the Eligibility Criteria".
Updated the corresponding label in the UI source file so that the new text appears in the modal.

## **New unit tests**
No new unit tests were added, as this is a UI label change only.

## **Unit tests executed by the author**
Not applicable for this change.
## **How to test manually**
Go to Programs > Create Program or Edit Program.
In the "Set Program Settings" modal, check the tab label previously showing "Configure the Default Eligibility Criteria".
Confirm it now reads "Configure the Eligibility Criteria".
Screenshot for reference:
## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/722

<img width="1810" height="208" alt="image" src="https://github.com/user-attachments/assets/0c521c37-25e9-43ab-92ac-fcc0ff594a95" />
