### PR TITLE
[IMP] module names

### DIFF
--- a/spp_audit_log/__manifest__.py
+++ b/spp_audit_log/__manifest__.py
@@ -1,5 +1,5 @@
 {
-    "name": "SPP Audit Log",
+    "name": "OpenSPP Audit Log",
     "summary": "Provides audit logging functionality to track data changes and user actions within OpenSPP, enhancing transparency and accountability.",
     "category": "OpenSPP",
     "version": "17.0.1.3.0",

--- a/spp_change_request_change_info/__manifest__.py
+++ b/spp_change_request_change_info/__manifest__.py
@@ -1,5 +1,5 @@
 {
-    "name": "Change Information Change Request",
+    "name": "OpenSPP Change Information Change Request",
     "category": "OpenSPP",
     "version": "17.0.1.3.0",
     "sequence": 1,

--- a/spp_hide_menus/__manifest__.py
+++ b/spp_hide_menus/__manifest__.py
@@ -2,7 +2,7 @@
 
 
 {
-    "name": "Hide Non-OpenSPP Menus",
+    "name": "OpenSPP Hide Non-OpenSPP Menus",
     "category": "OpenSPP",
     "version": "17.0.1.3.0",
     "sequence": 1,

--- a/spp_hide_menus_base/__manifest__.py
+++ b/spp_hide_menus_base/__manifest__.py
@@ -2,7 +2,7 @@
 
 
 {
-    "name": "Hide Non-OpenSPP Menus: Base",
+    "name": "OpenSPP Hide Non-OpenSPP Menus: Base",
     "category": "OpenSPP",
     "version": "17.0.1.3.0",
     "sequence": 1,

--- a/spp_idpass/__manifest__.py
+++ b/spp_idpass/__manifest__.py
@@ -2,7 +2,7 @@
 
 
 {
-    "name": "ID PASS",
+    "name": "OpenSPP ID PASS",
     "category": "OpenSPP",
     "version": "17.0.1.3.0",
     "sequence": 1,

--- a/spp_manual_eligibility/__manifest__.py
+++ b/spp_manual_eligibility/__manifest__.py
@@ -1,6 +1,6 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
 {
-    "name": "SPP Program: Manual Eligibility",
+    "name": "OpenSPP Program: Manual Eligibility",
     "category": "OpenSPP",
     "version": "17.0.1.3.0",
     "sequence": 1,

--- a/theme_openspp_muk/__manifest__.py
+++ b/theme_openspp_muk/__manifest__.py
@@ -1,5 +1,5 @@
 {
-    "name": "OpenSPP Theme (Muk Theme)",
+    "name": "OpenSPP Theme",
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/openspp-modules",
     "category": "OpenSPP",


### PR DESCRIPTION
## **Why is this change needed?**
Fix the names of modules. (Modules that don't have the name OpenSPP)

## **How was the change implemented?**
Modified the `__manifest__`

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
- On new deployment check the names of the modules (you can check the list on the ticket)
- Should be correct now.

## **Related links**

