### PR TITLE
Fix: make dev_setup.sh cross-platform (Windows & Linux/Mac) — follow-up to #770

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VENV_DIR=".venv"
+
+# Pick a Python command that exists
+if command -v python3 >/dev/null 2>&1; then
+  PY=python3
+elif command -v python >/dev/null 2>&1; then
+  PY=python
+elif command -v py >/dev/null 2>&1; then
+  PY="py -3"
+else
+  echo "❌ Python not found. Install Python 3 and try again."
+  exit 1
+fi
+
+# Create venv only if missing
+if [ ! -d "$VENV_DIR" ]; then
+  eval $PY -m venv "$VENV_DIR"
+fi
+
+# Activate (Linux/Mac = bin; Windows = Scripts)
+if [ -f "$VENV_DIR/bin/activate" ]; then
+  # shellcheck source=/dev/null
+  source "$VENV_DIR/bin/activate"
+elif [ -f "$VENV_DIR/Scripts/activate" ]; then
+  # shellcheck source=/dev/null
+  source "$VENV_DIR/Scripts/activate"
+else
+  echo "❌ Could not find activate script in $VENV_DIR"
+  exit 1
+fi
+
+# Upgrade pip
+python -m pip install --upgrade pip
+
+# Install deps if present
+if [ -f "requirements.txt" ]; then
+  pip install -r requirements.txt
+else
+  echo "ℹ️ No requirements.txt — skipping"
+fi
+
+echo "✅ Environment Ready"


### PR DESCRIPTION
This PR improves the developer setup script:

- Detects python via python3/python/py -3
- Creates venv only if missing
- Activates using bin/activate (Linux/Mac) or Scripts/activate (Windows)
- Upgrades pip
- Installs requirements.txt if present
- Shows clear status messages

Tested on Windows (Git Bash). 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a cross-platform `scripts/dev_setup.sh` that creates/activates a Python venv, upgrades pip, and installs `requirements.txt` if present.
> 
> - **Scripts**:
>   - **New `scripts/dev_setup.sh`**:
>     - Detects Python command (`python3`/`python`/`py -3`).
>     - Creates venv in `.venv` if missing and activates it (Linux/Mac `bin`, Windows `Scripts`).
>     - Upgrades `pip` and installs dependencies from `requirements.txt` when available.
>     - Emits clear success/error messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e33a1ff9e7ddb7e2b663d324a6a91e82cf6430f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->