### PR TITLE
[RMV] remove duplicated override of create method

### DIFF
--- a/spp_change_request/models/change_request.py
+++ b/spp_change_request/models/change_request.py
@@ -536,36 +536,6 @@ class ChangeRequestBase(models.Model):
             raise ValidationError(_("User is not allowed to approve CRs directly."))
         return self.request_type_ref_id._approve_cr(self)
 
-    # Override the create method to use the correct activity type
-    @api.model
-    def create(self, vals):
-        """
-        Creates a record for this model and generate activity
-
-        Usage:
-
-        - Add/Update key-value pair on vals before calling super
-        - Generate activity and add the activity to the result of super
-
-        :param dict vals: field name and value pair
-
-        :return recordset res:
-
-        :raise:
-        """
-
-        # Assign the CR to the current user by default
-        if "assign_to_id" not in vals or vals["assign_to_id"] is None:
-            vals["assign_to_id"] = self.env.user.id
-        vals["name"] = self.env["ir.sequence"].next_by_code("spp.change.request.num")
-        res = super().create(vals)
-        # Create pending validation activity
-        activity_type = "spp_change_request_base.pending_validation_activity"
-        summary = _("For Pending Validation")
-        note = _("A new change request was submitted. The next step will set this request to 'Pending Validation'.")
-        res._generate_activity(activity_type, summary, note)
-        return res
-
     # Override the action_cancel method to use the correct wizard reference
     def action_cancel(self):
         """


### PR DESCRIPTION
## **Why is this change needed?**

- Name sequence of change request is executed twice resulting to name sequence increased by 2
- e.g. CR-2025-000010, CR-2025-000012, CR-2025-000014

## **How was the change implemented?**

- Deleted the duplicate override of `create` method

## **New unit tests**

- none

## **Unit tests executed by the author**

- none

## **How to test manually**

- Create a new Change request
- Take note of the last two digit of the Change Request's name (e.g. CR-2025-000010)
- Create again a new Change request
- The last two digit of the second change request should only be increased by 1. (e.g CR-2025-000011)

## **Related links**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the duplicate `create` override in `spp_change_request/models/change_request.py` that set defaults and created a pending validation activity.
> 
> - **Backend**
>   - **ChangeRequestBase (`spp_change_request/models/change_request.py`)**: Remove overridden `create` method that:
>     - Defaulted `assign_to_id` to current user
>     - Generated `name` from `ir.sequence`
>     - Created a "pending validation" activity
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bac619f654325596ef19e93c6b93576792ff58a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->