### PR TITLE
[FIX] Fix and improve API Log

### DIFF
--- a/spp_api/controllers/api.py
+++ b/spp_api/controllers/api.py
@@ -35,7 +35,7 @@ _logger = logging.getLogger(__name__)
 #################################################################
 
 API_ENDPOINT = "/api"
-SENSITIVE_KEYS = ["Authorization", "Cookie", "X-Api-Key", "X-Odoo-Session-Id"]
+SENSITIVE_KEYS = {"authorization", "cookie", "x-api-key", "x-odoo-session-id"}
 
 
 def create_api_log(func):
@@ -56,7 +56,11 @@ def create_api_log(func):
 
         namespace_id = False
         if namespace:
-            namespace_id = request.env["spp_api.namespace"].search([("name", "=", namespace)])
+            version = kwargs.get("version")
+            search_domain = [("name", "=", namespace)]
+            if version:
+                search_domain.append(("version_name", "=", version))
+            namespace_id = request.env["spp_api.namespace"].search(search_domain, limit=1)
 
         initial_val = {
             "method": path.method,
@@ -85,12 +89,10 @@ def create_api_log(func):
             request_log_val["request_data"] = request_data
 
         # Sanitize headers
-        safe_headers = {}
-        for key, value in request.httprequest.headers.items():
-            if key in SENSITIVE_KEYS:
-                safe_headers[key] = "REDACTED"
-            else:
-                safe_headers[key] = value
+        safe_headers = {
+            key: "REDACTED" if key.lower() in SENSITIVE_KEYS else value
+            for key, value in request.httprequest.headers.items()
+        }
         request_log_val["headers"] = json.dumps(safe_headers)
 
         request.env["spp_api.log"].create(request_log_val)

--- a/spp_api/controllers/api.py
+++ b/spp_api/controllers/api.py
@@ -79,7 +79,7 @@ def create_api_log(func):
         # silent=True prevents Werkzeug from raising a 400 error on bad JSON
         json_payload = request.httprequest.get_json(silent=True)
 
-        if json_payload:
+        if json_payload is not None:
             request_data = json.dumps(json_payload)
         else:
             # Fallback to raw data if not JSON

--- a/spp_api/controllers/api.py
+++ b/spp_api/controllers/api.py
@@ -35,6 +35,7 @@ _logger = logging.getLogger(__name__)
 #################################################################
 
 API_ENDPOINT = "/api"
+SENSITIVE_KEYS = ["Authorization", "Cookie", "X-Api-Key", "X-Odoo-Session-Id"]
 
 
 def create_api_log(func):
@@ -43,6 +44,7 @@ def create_api_log(func):
         # Request Log
         path = kwargs.get("path")
         request_id = kwargs.get("request_id", False)
+        namespace = kwargs.get("namespace", False)
         if not request_id:
             raise werkzeug.exceptions.HTTPException(
                 response=error_response(400, "Bad Request", "request_id is required.")
@@ -52,10 +54,15 @@ def create_api_log(func):
                 response=error_response(400, "Bad Request", "request_id is already taken.")
             )
 
+        namespace_id = False
+        if namespace:
+            namespace_id = request.env["spp_api.namespace"].search([("name", "=", namespace)])
+
         initial_val = {
             "method": path.method,
             "model": path.model,
             "request": http.request.httprequest.full_path,
+            "namespace_id": namespace_id.id if namespace_id else False,
         }
 
         request_log_val = initial_val.copy()
@@ -64,7 +71,27 @@ def create_api_log(func):
         if path.method in ["get"]:
             request_log_val["request_parameter"] = kwargs
         else:
-            request_log_val["request_data"] = kwargs
+            # Try to get parsed JSON first
+            # silent=True prevents Werkzeug from raising a 400 error on bad JSON
+            json_payload = request.httprequest.get_json(silent=True)
+
+            if json_payload:
+                request_data = json.dumps(json_payload)
+            else:
+                # Fallback to raw data if not JSON
+                # errors='replace' inserts a  character instead of crashing on bad bytes
+                request_data = request.httprequest.get_data().decode("utf-8", errors="replace")
+
+            request_log_val["request_data"] = request_data
+
+        # Sanitize headers
+        safe_headers = {}
+        for key, value in request.httprequest.headers.items():
+            if key in SENSITIVE_KEYS:
+                safe_headers[key] = "REDACTED"
+            else:
+                safe_headers[key] = value
+        request_log_val["headers"] = json.dumps(safe_headers)
 
         request.env["spp_api.log"].create(request_log_val)
         del request_log_val

--- a/spp_api/controllers/api.py
+++ b/spp_api/controllers/api.py
@@ -72,21 +72,21 @@ def create_api_log(func):
         request_log_val = initial_val.copy()
         request_log_val["http_type"] = "request"
         request_log_val["request_id"] = request_id
-        if path.method in ["get"]:
-            request_log_val["request_parameter"] = kwargs
+
+        request_log_val["request_parameter"] = request.httprequest.query_string.decode("utf-8", errors="replace")
+
+        # Try to get parsed JSON first
+        # silent=True prevents Werkzeug from raising a 400 error on bad JSON
+        json_payload = request.httprequest.get_json(silent=True)
+
+        if json_payload:
+            request_data = json.dumps(json_payload)
         else:
-            # Try to get parsed JSON first
-            # silent=True prevents Werkzeug from raising a 400 error on bad JSON
-            json_payload = request.httprequest.get_json(silent=True)
+            # Fallback to raw data if not JSON
+            # errors='replace' inserts a  character instead of crashing on bad bytes
+            request_data = request.httprequest.get_data().decode("utf-8", errors="replace")
 
-            if json_payload:
-                request_data = json.dumps(json_payload)
-            else:
-                # Fallback to raw data if not JSON
-                # errors='replace' inserts a  character instead of crashing on bad bytes
-                request_data = request.httprequest.get_data().decode("utf-8", errors="replace")
-
-            request_log_val["request_data"] = request_data
+        request_log_val["request_data"] = request_data
 
         # Sanitize headers
         safe_headers = {

--- a/spp_api/models/spp_api_log.py
+++ b/spp_api/models/spp_api_log.py
@@ -28,6 +28,7 @@ class Log(models.Model):
     )
     model = fields.Char(required=True)
     namespace_id = fields.Many2one("spp_api.namespace", "Integration")
+    headers = fields.Text()
     request = fields.Text()
 
     request_id = fields.Text(string="Request ID")

--- a/spp_api/views/openapi_view.xml
+++ b/spp_api/views/openapi_view.xml
@@ -46,6 +46,7 @@
                     <field name="create_date" readonly="1" />
                     <field name="request" readonly="1" />
                     <field name="headers" readonly="1" />
+                    <field name="request_parameter" readonly="1" />
                     <field name="request_data" readonly="1" />
                     <field name="response_data" readonly="1" />
                 </group>

--- a/spp_api/views/openapi_view.xml
+++ b/spp_api/views/openapi_view.xml
@@ -45,6 +45,7 @@
                     <field name="create_uid" readonly="1" />
                     <field name="create_date" readonly="1" />
                     <field name="request" readonly="1" />
+                    <field name="headers" readonly="1" />
                     <field name="request_data" readonly="1" />
                     <field name="response_data" readonly="1" />
                 </group>
@@ -302,7 +303,7 @@
     <record model="ir.actions.act_window" id="spp_api_log_list_action">
         <field name="name">API Logs</field>
         <field name="res_model">spp_api.log</field>
-        <field name="view_mode">tree</field>
+        <field name="view_mode">tree,form</field>
         <field name="help">List of API Logs.</field>
     </record>
 


### PR DESCRIPTION
## **Why is this change needed?**

Encountered several problems regaring logging of API
- Unable to open the form view of API Log
- Saved Request Data is not correct
- Saved log doesn't have a relation with the namespace

<img width="2930" height="732" alt="image" src="https://github.com/user-attachments/assets/686676aa-d4b1-4aa7-a422-4e7ca003da7c" />
<img width="2626" height="856" alt="image" src="https://github.com/user-attachments/assets/8c5377f6-f2f6-49f5-8e71-2df4abcb49a4" />

## **How was the change implemented?**

- Added `form` in the `view_mode` of `spp_api_log_list_action` to be able to view the form view
- Added namespace_id to the API Log
- Corrected saved Request Data
- Added Headers field

## **New unit tests**

None

## **Unit tests executed by the author**

None

## **How to test manually**

## **Related links**

After the fix screenshots
<img width="2908" height="940" alt="image" src="https://github.com/user-attachments/assets/866b7fab-dd89-4239-8119-3a200de60a60" />

<img width="2920" height="224" alt="image" src="https://github.com/user-attachments/assets/e8693858-7821-43bd-84b8-9a804b1d8a06" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Logging now persists request bodies and headers (even though sensitive keys are redacted), which increases exposure risk if other secrets appear in payloads/headers and may impact storage volume/performance.
> 
> **Overview**
> Fixes and enriches OpenAPI request/response logging. Request logs now link to the resolved `spp_api.namespace` (optionally matching `version`), store the raw query string, capture request bodies more accurately (parsed JSON when possible, else decoded raw bytes), and persist sanitized HTTP headers with sensitive values redacted.
> 
> Updates the `spp_api.log` model/UI to support this data by adding a `headers` field, exposing `headers` and `request_parameter` on the log form, and enabling `tree,form` view mode so logs can be opened from the list view.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d604986cd82180083eb2243b0bda40d7595ae44a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->