### PR TITLE
[UPD] add pagination to GET API response

### DIFF
--- a/spp_api/__manifest__.py
+++ b/spp_api/__manifest__.py
@@ -7,7 +7,7 @@
     "images": [
         "images/icon.png",
     ],
-    "version": "17.0.1.3.1",
+    "version": "17.0.1.4.1",
     "application": False,
     "author": "OpenSPP.org",
     "development_status": "Production/Stable",

--- a/spp_api/controllers/api.py
+++ b/spp_api/controllers/api.py
@@ -207,7 +207,17 @@ class ApiV1Controller(http.Controller):
         path = kw.get("path")
         del kw["path"]
 
-        page = kw.get("page", 1)
+        # For backward compatibility
+        # Will not use pagination
+        backward_compat = False
+        if "start_from" in kw:
+            backward_compat = True
+
+        try:
+            page = int(kw.get("page", 1))
+        except (ValueError, TypeError):
+            page = 1
+        page = max(1, page)
 
         kw = path.search_treatment_kwargs(kw)
         limit = kw.get("limit")
@@ -217,20 +227,24 @@ class ApiV1Controller(http.Controller):
         records_all = records.search_count(kw.get("domain"))
         records_data = path._get_response_treatment(records_data)
 
-        pagination = {
-            "page": page,
-            "limit": limit,
-            "total_records": records_all,
-            "total_pages": (records_all + limit - 1) // limit,
-        }
-
         response_data = {
             "results": records_data,
             "version": version,
             "timestamp": datetime_format(datetime.datetime.now()),
             "reply_id": self.get_reply_id(),
-            "pagination": pagination,
         }
+
+        if backward_compat:
+            response_data["count"] = records_all
+            response_data["offset"] = kw.get("offset", 0)
+            response_data["limit"] = limit
+        else:
+            response_data["pagination"] = {
+                "page": page,
+                "limit": limit,
+                "total_records": records_all,
+                "total_pages": (records_all + limit - 1) // limit if limit > 0 else 1,
+            }
 
         return successful_response(200, response_data)
 

--- a/spp_api/controllers/api.py
+++ b/spp_api/controllers/api.py
@@ -207,19 +207,29 @@ class ApiV1Controller(http.Controller):
         path = kw.get("path")
         del kw["path"]
 
+        page = kw.get("page", 1)
+
         kw = path.search_treatment_kwargs(kw)
+        limit = kw.get("limit")
+
         records = self.get_records(path.model, kw)
         records_data = records.search_read(**kw)
         records_all = records.search_count(kw.get("domain"))
         records_data = path._get_response_treatment(records_data)
+
+        pagination = {
+            "page": page,
+            "limit": limit,
+            "total_records": records_all,
+            "total_pages": (records_all + limit - 1) // limit,
+        }
+
         response_data = {
             "results": records_data,
-            "count": records_all,
-            "offset": kw.get("offset", 0),
-            "limit": kw.get("limit", 0),
             "version": version,
             "timestamp": datetime_format(datetime.datetime.now()),
             "reply_id": self.get_reply_id(),
+            "pagination": pagination,
         }
 
         return successful_response(200, response_data)

--- a/spp_api/controllers/api.py
+++ b/spp_api/controllers/api.py
@@ -218,6 +218,7 @@ class ApiV1Controller(http.Controller):
         except (ValueError, TypeError):
             page = 1
         page = max(1, page)
+        kw["page"] = page
 
         kw = path.search_treatment_kwargs(kw)
         limit = kw.get("limit")
@@ -243,7 +244,7 @@ class ApiV1Controller(http.Controller):
                 "page": page,
                 "limit": limit,
                 "total_records": records_all,
-                "total_pages": (records_all + limit - 1) // limit if limit > 0 else 1,
+                "total_pages": max(1, (records_all + limit - 1) // limit if limit > 0 else 1),
             }
 
         return successful_response(200, response_data)

--- a/spp_api/models/spp_api_path.py
+++ b/spp_api/models/spp_api_path.py
@@ -89,7 +89,7 @@ class SPPAPIPath(models.Model):
     # Read
     filter_domain = fields.Char(default="[]")
     field_ids = fields.Many2many("ir.model.fields", domain="[('model_id', '=', model_id)]", string="Fields")
-    limit = fields.Integer(string="Limit of results", default=80, help="Limit of results per page")
+    limit = fields.Integer(string="Limit of results", default=500, help="Limit of results per page")
     # Create / Update
     warning_required = fields.Boolean(compute="_compute_warning_required", compute_sudo=True)
     api_field_ids = fields.One2many("spp_api.field", "path_id", string="API Fields", copy=True)
@@ -663,24 +663,43 @@ class SPPAPIPath(models.Model):
         """
         self.ensure_one()
 
-        # Page
-        page = kwargs.get("page", 1)
+        backward_compat = False
+        if "start_from" in kwargs:
+            backward_compat = True
 
-        # Get defined limit first in spp_api.path
-        # if limit is defined in kwargs (query parameter), use it; else use self.limit or MAX_LIMIT
-        limit = kwargs.get("limit", self.limit if self.limit else MAX_LIMIT)
+        if backward_compat:
+            limit = kwargs.get("limit", 0)
+            max_limit = self.limit if self.limit else MAX_LIMIT
+            kwargs["limit"] = limit if (limit and limit <= max_limit) else max_limit
+            kwargs["offset"] = kwargs.get("start_from", 0)
+            if "start_from" in kwargs:
+                del kwargs["start_from"]
+        else:
+            # Page
+            try:
+                page = int(kwargs.get("page", 1))
+            except (ValueError, TypeError):
+                page = 1
+            page = max(1, page)
 
-        # Validate limit
-        try:
-            limit = int(limit)
-        except (ValueError, TypeError):
-            limit = self.limit if self.limit else MAX_LIMIT
+            # Get defined limit first in spp_api.path
+            # if limit is defined in kwargs (query parameter), use it; else use self.limit or MAX_LIMIT
+            max_limit = self.limit if self.limit else MAX_LIMIT
+            limit = kwargs.get("limit", max_limit)
 
-        kwargs["limit"] = limit
+            # Validate limit
+            try:
+                limit = int(limit)
+                if limit <= 0 or limit > max_limit:
+                    limit = max_limit
+            except (ValueError, TypeError):
+                limit = max_limit
 
-        # Offset
-        offset = (page - 1) * limit if page > 1 else kwargs.get("offset", 0)
-        kwargs["offset"] = offset
+            kwargs["limit"] = limit
+
+            # Offset
+            offset = (page - 1) * limit
+            kwargs["offset"] = offset
 
         # Domain
         kwargs["domain"] = self.get_domain(kwargs)

--- a/spp_api/models/spp_api_path.py
+++ b/spp_api/models/spp_api_path.py
@@ -676,11 +676,7 @@ class SPPAPIPath(models.Model):
                 del kwargs["start_from"]
         else:
             # Page
-            try:
-                page = int(kwargs.get("page", 1))
-            except (ValueError, TypeError):
-                page = 1
-            page = max(1, page)
+            page = int(kwargs.get("page", 1))
 
             # Get defined limit first in spp_api.path
             # if limit is defined in kwargs (query parameter), use it; else use self.limit or MAX_LIMIT

--- a/spp_api/models/spp_api_path.py
+++ b/spp_api/models/spp_api_path.py
@@ -89,7 +89,7 @@ class SPPAPIPath(models.Model):
     # Read
     filter_domain = fields.Char(default="[]")
     field_ids = fields.Many2many("ir.model.fields", domain="[('model_id', '=', model_id)]", string="Fields")
-    limit = fields.Integer(string="Limit of results", default=500)
+    limit = fields.Integer(string="Limit of results", default=80, help="Limit of results per page")
     # Create / Update
     warning_required = fields.Boolean(compute="_compute_warning_required", compute_sudo=True)
     api_field_ids = fields.One2many("spp_api.field", "path_id", string="API Fields", copy=True)
@@ -663,15 +663,24 @@ class SPPAPIPath(models.Model):
         """
         self.ensure_one()
 
-        # Limit
-        limit = kwargs.get("limit", 0)
-        max_limit = self.limit if self.limit else MAX_LIMIT
-        kwargs["limit"] = limit if (limit and limit <= max_limit) else max_limit
+        # Page
+        page = kwargs.get("page", 1)
+
+        # Get defined limit first in spp_api.path
+        # if limit is defined in kwargs (query parameter), use it; else use self.limit or MAX_LIMIT
+        limit = kwargs.get("limit", self.limit if self.limit else MAX_LIMIT)
+
+        # Validate limit
+        try:
+            limit = int(limit)
+        except (ValueError, TypeError):
+            limit = self.limit if self.limit else MAX_LIMIT
+
+        kwargs["limit"] = limit
 
         # Offset
-        kwargs["offset"] = kwargs.get("start_from", 0)
-        if "start_from" in kwargs:
-            del kwargs["start_from"]
+        offset = (page - 1) * limit if page > 1 else kwargs.get("offset", 0)
+        kwargs["offset"] = offset
 
         # Domain
         kwargs["domain"] = self.get_domain(kwargs)


### PR DESCRIPTION
## **Why is this change needed?**

To add a pagination to the GET API Response

## **How was the change implemented?**

retrieving limit in this specific order if incase any of them is not available
- queryparameter
- spp_api.path limit field
- Hard Limit of 500

page can now be defined in queryparameter

Add a pagination to the response 

## **New unit tests**

## **Unit tests executed by the author**

## **How to test manually**

## **Related links**

# Sample Response

## Before the update

```
GET /api/registry/v1/households?request_id=72cd9d6f-48be-41c6-0016-4a2fdd2a86a2
{
    "results": [
        {
            "sample": "response"
        }
    ],
    "count": 1,
    "offset": 0,
    "limit": 1,
    "version": "v1",
    "timestamp": "2026-02-05T07:04:36.589Z",
    "reply_id": "770f07ad-678d-47e7-9131-94909e6a6115"
}
```

## After the update

No page and no limit
default page is 1, default limit is based on what is indicated in limit field of spp_api.path
GET /api/registry/v1/households?request_id=72cd9d6f-48be-41c6-0016-4a2fdd2a86a2

```
{
    "results": [
        {
            "sample": "response"
        }
    ],
    "version": "v1",
    "timestamp": "2026-02-05T08:59:34.419Z",
    "reply_id": "002d7c34-bfd2-42b1-a7c4-9777c3367d8b",
    "pagination": {
        "page": 1,
        "limit": 500,
        "total_records": 1116,
        "total_pages": 3
    }
}
```

With page and limit
GET /api/registry/v1/households?request_id=72cd9d6f-48be-41c6-0016-4a2fdd2a86a2&page=2&limit=80

```
{
    "results": [
        {
            "sample": "response"
        }
    ],
    "version": "v1",
    "timestamp": "2026-02-05T09:06:11.110Z",
    "reply_id": "791c67ae-2b7d-4bb5-b784-fabcdb8e3769",
    "pagination": {
        "page": 2,
        "limit": 80,
        "total_records": 1116,
        "total_pages": 14
    }
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape of `GET` list responses and modifies limit/offset handling, which can break API clients that relied on the previous fields or pagination semantics.
> 
> **Overview**
> Adds page-based pagination to `GET` collection endpoints: query `page` is normalized, `offset` is computed as `(page-1)*limit`, and responses now return a `pagination` object with `page`, `limit`, `total_records`, and `total_pages`.
> 
> Keeps backward compatibility for callers using `start_from` by preserving the legacy `count`/`offset`/`limit` response fields and offset behavior. Also bumps the module version and clarifies `spp_api.path.limit` as a per-page limit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 156107342f9d0fb44e7bd68d4c886917ebd4f73d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->